### PR TITLE
Improve udivmod4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+.idea

--- a/src/intrinsics/native/divmod.rs
+++ b/src/intrinsics/native/divmod.rs
@@ -154,7 +154,7 @@ pub fn udivmod4(
         // const ti_int s =
         //     (ti_int)(divisor.all - dividend.all - 1) >> (n_utword_bits - 1);
         let mut s = divisor.wrapping_sub(dividend).wrapping_sub(U256::ONE);
-        s = U256::from_words((*s.high() as i128 >> 127) as u128, s.high() >> 127);
+        s = U256::from_words((*s.high() as i128 >> 127) as u128, (*s.high() as i128 >> 127) as u128);
 
         *quotient.low_mut() = *quotient.low() | (s & 1).as_u128();
         dividend -= divisor & s;

--- a/src/intrinsics/native/divmod.rs
+++ b/src/intrinsics/native/divmod.rs
@@ -154,7 +154,10 @@ pub fn udivmod4(
         // const ti_int s =
         //     (ti_int)(divisor.all - dividend.all - 1) >> (n_utword_bits - 1);
         let mut s = divisor.wrapping_sub(dividend).wrapping_sub(U256::ONE);
-        s = U256::from_words((*s.high() as i128 >> 127) as u128, (*s.high() as i128 >> 127) as u128);
+        s = U256::from_words(
+            (*s.high() as i128 >> 127) as u128,
+            (*s.high() as i128 >> 127) as u128,
+        );
 
         *quotient.low_mut() = *quotient.low() | (s & 1).as_u128();
         dividend -= divisor & s;

--- a/src/intrinsics/native/divmod.rs
+++ b/src/intrinsics/native/divmod.rs
@@ -6,10 +6,80 @@
 //! 256-bit unsigned division.
 //!
 //! This source is ported from LLVM project from C:
-//! https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/udivmodti4.c
+//! https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/udivmodti4.c
 
-use crate::{AsU256, U256};
+use crate::U256;
 use core::mem::MaybeUninit;
+
+#[inline]
+fn udiv256by128to128(u1: u128, u0: u128, mut v: u128, r: &mut u128) -> u128 {
+    const N_UDWORD_BITS: u32 = 128;
+    const BASE: u128 = 1 << (N_UDWORD_BITS / 2); // Number base (64 bits)
+    let (un1, un0): (u128, u128); // Norm. dividend LSD's
+    let (vn1, vn0): (u128, u128); // Norm. divisor digits
+    let (mut q1, mut q0): (u128, u128); // Quotient digits
+    let (un128, un21, un10): (u128, u128, u128); // Dividend digit pairs
+    let mut rhat: u128; // A remainder
+
+    // Shift amount for normalization
+    let s: u32 = v.leading_zeros();
+    if s > 0 {
+        // Normalize the divisor.
+        v <<= s;
+        un128 = (u1 << s) | (u0 >> (N_UDWORD_BITS - s));
+        un10 = u0 << s; // Shift dividend left
+    } else {
+        // Avoid undefined behavior of (u0 >> 64).
+        un128 = u1;
+        un10 = u0;
+    }
+
+    // Break divisor up into two 64-bit digits.
+    vn1 = v >> (N_UDWORD_BITS / 2);
+    vn0 = v & 0xFFFF_FFFF_FFFF_FFFF;
+
+    // Break right half of dividend into two digits.
+    un1 = un10 >> (N_UDWORD_BITS / 2);
+    un0 = un10 & 0xFFFF_FFFF_FFFF_FFFF;
+
+    // Compute the first quotient digit, q1.
+    q1 = un128 / vn1;
+    rhat = un128 - q1 * vn1;
+
+    // q1 has at most error 2. No more than 2 iterations.
+    while q1 >= BASE || q1 * vn0 > BASE * rhat + un1 {
+        q1 -= 1;
+        rhat += vn1;
+        if rhat >= BASE {
+            break;
+        }
+    }
+
+    un21 = un128
+        .wrapping_mul(BASE)
+        .wrapping_add(un1)
+        .wrapping_sub(q1.wrapping_mul(v));
+
+    // Compute the second quotient digit.
+    q0 = un21 / vn1;
+    rhat = un21 - q0 * vn1;
+
+    // q0 has at most error 2. No more than 2 iterations.
+    while q0 >= BASE || q0 * vn0 > BASE * rhat + un0 {
+        q0 -= 1;
+        rhat += vn1;
+        if rhat >= BASE {
+            break;
+        }
+    }
+
+    *r = (un21
+        .wrapping_mul(BASE)
+        .wrapping_add(un0)
+        .wrapping_sub(q0.wrapping_mul(v)))
+        >> s;
+    q1 * BASE + q0
+}
 
 #[allow(clippy::many_single_char_names)]
 pub fn udivmod4(
@@ -24,219 +94,76 @@ pub fn udivmod4(
         };
     }
 
-    const N_UDWORD_BITS: u32 = 128;
-    const N_UTWORD_BITS: u32 = 256;
-    let n = a;
-    let d = b;
-    let mut q = MaybeUninit::<U256>::uninit();
-    let mut r = MaybeUninit::<U256>::uninit();
-    let mut sr: u32;
-    // special cases, X is unknown, K != 0
-    if *n.high() == 0 {
-        if *d.high() == 0 {
-            // 0 X
-            // ---
-            // 0 X
-            if let Some(rem) = rem {
-                set!(rem = U256::new(n.low() % d.low()));
-            }
-            set!(res = U256::new(n.low() / d.low()));
-            return;
-        }
-        // 0 X
-        // ---
-        // K X
+    let dividend = a;
+    let divisor = b;
+
+    if divisor > dividend {
         if let Some(rem) = rem {
-            set!(rem = U256::new(*n.low()));
+            set!(rem = *dividend);
         }
         set!(res = U256::ZERO);
         return;
     }
-    // n.high() != 0
-    if *d.low() == 0 {
-        if *d.high() == 0 {
-            // K X
-            // ---
-            // 0 0
-            if let Some(rem) = rem {
-                set!(rem = U256::new(n.high() % d.low()));
-            }
-            set!(res = U256::new(n.high() / d.low()));
-            return;
-        }
-        // d.high() != 0
-        if *n.low() == 0 {
-            // K 0
-            // ---
-            // K 0
-            if let Some(rem) = rem {
-                set!(rem = U256::from_words(n.high() % d.high(), 0));
-            }
-            set!(res = U256::new(n.high() / d.high()));
-            return;
-        }
-        // K K
-        // ---
-        // K 0
-        // NOTE: Modified from `if (d.high() & (d.high() - 1)) == 0`
-        if d.high().is_power_of_two() {
-            /* if d is a power of 2 */
-            if let Some(rem) = rem {
-                set!(rem = U256::from_words(n.high() & (d.high() - 1), *n.low()));
-            }
-            set!(res = U256::new(n.high() >> d.high().trailing_zeros()));
-            return;
-        }
-        // K K
-        // ---
-        // K 0
-        sr = d
-            .high()
-            .leading_zeros()
-            .wrapping_sub(n.high().leading_zeros());
-        // 0 <= sr <= N_UDWORD_BITS - 2 or sr large
-        if sr > N_UDWORD_BITS - 2 {
-            if let Some(rem) = rem {
-                set!(rem = *n);
-            }
-            set!(res = U256::ZERO);
-            return;
-        }
-        sr += 1;
-        // 1 <= sr <= N_UDWORD_BITS - 1
-        // q.all = n.all << (N_UTWORD_BITS - sr);
-        set!(q = U256::from_words(n.low() << (N_UDWORD_BITS - sr), 0));
-        // r.all = n.all >> sr;
-        set!(
-            r = U256::from_words(
-                n.high() >> sr,
-                (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-            )
-        );
-    } else {
-        /* d.low() != 0 */
-        if *d.high() == 0 {
-            // K X
-            // ---
-            // 0 K
-            // NOTE: Modified from `if (d.low() & (d.low() - 1)) == 0`.
-            if d.low().is_power_of_two() {
-                /* if d is a power of 2 */
-                if let Some(rem) = rem {
-                    set!(rem = U256::new(n.low() & (d.low() - 1)));
-                }
-                if *d.low() == 1 {
-                    set!(res = *n);
-                    return;
-                }
-                sr = d.low().trailing_zeros();
-                set!(
-                    res = U256::from_words(
-                        n.high() >> sr,
-                        (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-                    )
-                );
-                return;
-            }
-            // K X
-            // ---
-            // 0 K
-            sr = 1 + N_UDWORD_BITS + d.low().leading_zeros() - (n.high()).leading_zeros();
-            // 2 <= sr <= N_UTWORD_BITS - 1
-            // q.all = n.all << (N_UTWORD_BITS - sr);
-            // r.all = n.all >> sr;
-            #[allow(clippy::comparison_chain)]
-            if sr == N_UDWORD_BITS {
-                set!(q = U256::from_words(*n.low(), 0));
-                set!(r = U256::from_words(0, *n.high()));
-            } else if sr < N_UDWORD_BITS {
-                /* 2 <= sr <= N_UDWORD_BITS - 1 */
-                set!(q = U256::from_words(n.low() << (N_UDWORD_BITS - sr), 0));
-                set!(
-                    r = U256::from_words(
-                        n.high() >> sr,
-                        (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-                    )
-                );
-            } else {
-                /* N_UDWORD_BITS + 1 <= sr <= N_UTWORD_BITS - 1 */
-                set!(
-                    q = U256::from_words(
-                        (n.high() << (N_UTWORD_BITS - sr)) | (n.low() >> (sr - N_UDWORD_BITS)),
-                        n.low() << (N_UTWORD_BITS - sr),
-                    )
-                );
-                set!(r = U256::from_words(0, n.high() >> (sr - N_UDWORD_BITS)));
-            }
-        } else {
-            // K X
-            // ---
-            // K K
-            sr = (d.high())
-                .leading_zeros()
-                .wrapping_sub((n.high()).leading_zeros());
-            // 0 <= sr <= N_UDWORD_BITS - 1 or sr large
-            if sr > N_UDWORD_BITS - 1 {
-                if let Some(rem) = rem {
-                    set!(rem = *n);
-                }
-                set!(res = U256::ZERO);
-                return;
-            }
-            sr += 1;
-            // 1 <= sr <= N_UDWORD_BITS
-            // q.all = n.all << (N_UTWORD_BITS - sr);
-            // r.all = n.all >> sr;
-            if sr == N_UDWORD_BITS {
-                set!(q = U256::from_words(*n.low(), 0));
-                set!(r = U256::from_words(0, *n.high()));
-            } else {
-                set!(
-                    r = U256::from_words(
-                        n.high() >> sr,
-                        (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-                    )
-                );
-                set!(q = U256::from_words(n.low() << (N_UDWORD_BITS - sr), 0));
-            }
-        }
-    }
-    // Not a special case
-    // q and r are initialized with:
-    // q.all = n.all << (N_UTWORD_BITS - sr);
-    // r.all = n.all >> sr;
-    // 1 <= sr <= N_UTWORD_BITS - 1
-    let mut carry = 0u128;
-    let mut q = unsafe { q.assume_init() };
-    let mut r = unsafe { r.assume_init() };
-    while sr > 0 {
-        // r:q = ((r:q)  << 1) | carry
-        *r.high_mut() = (r.high() << 1) | (r.low() >> (N_UDWORD_BITS - 1));
-        *r.low_mut() = (r.low() << 1) | (q.high() >> (N_UDWORD_BITS - 1));
-        *q.high_mut() = (q.high() << 1) | (q.low() >> (N_UDWORD_BITS - 1));
-        *q.low_mut() = (q.low() << 1) | carry;
-        // carry = 0;
-        // if (r.all >= d.all)
-        // {
-        //     r.all -= d.all;
-        //      carry = 1;
-        // }
-        // NOTE: Modified from `(d - r - 1) >> (N_UTWORD_BITS - 1)` to be an
-        // **arithmetic** shift.
-        let s = {
-            let (hi, _) = d.wrapping_sub(r).wrapping_sub(U256::ONE).into_words();
-            ((hi as i128) >> 127).as_u256()
-        };
-        carry = s.low() & 1;
-        r -= d & s;
 
-        sr -= 1;
+    let mut quotient = U256::ZERO;
+
+    // When the divisor fits in 128 bits, we can use an optimized path.
+    if *divisor.high() == 0 {
+        let mut remainder = U256::ZERO;
+
+        if dividend.high() < divisor.low() {
+            // The result fits in 128 bits.
+            *quotient.low_mut() = udiv256by128to128(
+                *dividend.high(),
+                *dividend.low(),
+                *divisor.low(),
+                remainder.low_mut(),
+            );
+        } else {
+            // First, divide with the high part to get the remainder in dividend.high.
+            // After that dividend.high < divisor.low.
+            *quotient.high_mut() = dividend.high() / divisor.low();
+            let dividend_high = dividend.high() % divisor.low();
+            *quotient.low_mut() = udiv256by128to128(
+                dividend_high,
+                *dividend.low(),
+                *divisor.low(),
+                remainder.low_mut(),
+            );
+        }
+        if let Some(rem) = rem {
+            set!(rem = remainder);
+        }
+        set!(res = quotient);
+        return;
     }
-    q = (q << 1) | U256::new(carry);
+
+    // 0 <= shift <= 127.
+    let shift = divisor.high().leading_zeros() - dividend.high().leading_zeros();
+    let mut divisor = divisor << shift;
+    let mut dividend = *dividend;
+    for _ in 0..=shift {
+        *quotient.low_mut() = quotient.low().wrapping_shl(1);
+        // Branch free version of.
+        // if (dividend >= divisor)
+        // {
+        //    dividend -= divisor;
+        //    carry = 1;
+        // }
+
+        // const ti_int s =
+        //     (ti_int)(divisor.all - dividend.all - 1) >> (n_utword_bits - 1);
+        let mut s = divisor.wrapping_sub(dividend).wrapping_sub(U256::ONE);
+        s = U256::from_words((*s.high() as i128 >> 127) as u128, s.high() >> 127);
+
+        *quotient.low_mut() = *quotient.low() | (s & 1).as_u128();
+        dividend -= divisor & s;
+        divisor >>= 1;
+    }
     if let Some(rem) = rem {
-        set!(rem = r);
+        set!(rem = dividend);
     }
-    set!(res = q);
+    set!(res = quotient);
 }
 
 pub fn div2(r: &mut U256, a: &U256) {
@@ -268,6 +195,7 @@ pub fn rem3(r: &mut MaybeUninit<U256>, a: &U256, b: &U256) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AsU256;
 
     fn div(a: impl AsU256, b: impl AsU256) -> U256 {
         let mut r = MaybeUninit::uninit();


### PR DESCRIPTION
Hi @nlordell,

`udivmodti4` in LLVM has been optimized for many platforms: https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/udivmodti4.c.

I ported the new version here.

In my [`decimal-rs`](https://github.com/cod-technologies/decimal-rs) benchmark, there is a significant performance improvement.

Before: 
```
test decimal_div       ... bench:         910 ns/iter (+/- 113)
```

After:
```
test decimal_div       ... bench:         289 ns/iter (+/- 42)
```

But there's a terrible problem, a test case in `intrinsics::native::divmod::tests::remainder` failed.

```
--- intrinsics::native::divmod::tests::remainder stdout ----
thread 'intrinsics::native::divmod::tests::remainder' panicked at 'assertion failed: `(left == right)`
  left: `7486212072260646196194241363498900652031`,
 right: `6125082604576892342340742933771827806237`', src/intrinsics/native/divmod.rs:315:9
```

I spent the whole evening trying to solve the problem, but couldn't get to the root of it.

Could you find time to have a look at it?