### PR TITLE
`udivmod` based on Knuth division

### DIFF
--- a/src/intrinsics/native/divmod.rs
+++ b/src/intrinsics/native/divmod.rs
@@ -6,12 +6,97 @@
 //! 256-bit unsigned division.
 //!
 //! This source is ported from LLVM project from C:
-//! https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/udivmodti4.c
+//! https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/udivmodti4.c
 
-use crate::{AsU256, U256};
+use crate::U256;
 use core::mem::MaybeUninit;
 
-#[allow(clippy::many_single_char_names)]
+#[inline(always)]
+fn udiv256_by_64_to_64(u1: u128, u0: u128, mut v: u128, r: &mut u128) -> u128 {
+    const N_UDWORD_BITS: u32 = 128;
+    const B: u128 = 1 << (N_UDWORD_BITS / 2); /* Number base (64 bits) */
+
+    // Norm. dividend LSD's
+    let un1: u128;
+    let un0: u128;
+    // Norm. divisor digits
+    let vn1: u128;
+    let vn0: u128;
+
+    // Quotient digits
+    let mut q1: u128;
+    let mut q0: u128;
+
+    // Dividend digit pairs
+    let un64: u128;
+    let un21: u128;
+    let un10: u128;
+
+    // A remainder
+    let mut rhat: u128;
+
+    // Shift amount for normalization
+    let s: u32;
+
+    s = v.leading_zeros();
+    if s > 0 {
+        // Normalize the divisor.
+        v <<= s;
+        un64 = (u1 << s) | (u0 >> (N_UDWORD_BITS - s));
+        un10 = u0 << s; // Shift dividend left
+    } else {
+        // Avoid undefined behavior of (u0 >> 64).
+        un64 = u1;
+        un10 = u0;
+    }
+
+    // Break divisor up into two 32-bit digits.
+    vn1 = v >> (N_UDWORD_BITS / 2);
+    vn0 = v & 0xffffffff;
+
+    // Break right half of dividend into two digits.
+    un1 = un10 >> (N_UDWORD_BITS / 2);
+    un0 = un10 & 0xffffffff;
+
+    // Compute the first quotient digit, q1.
+    q1 = un64 / vn1;
+    rhat = un64 - q1 * vn1;
+
+    // q1 has at most error 2. No more than 2 iterations.
+    while q1 >= B || q1 * vn0 > B * rhat + un1 {
+        q1 -= 1;
+        rhat += vn1;
+        if rhat >= B {
+            break;
+        }
+    }
+
+    un21 = un64
+        .wrapping_mul(B)
+        .wrapping_add(un1)
+        .wrapping_sub(q1.wrapping_mul(v));
+
+    // Compute the second quotient digit.
+    q0 = un21 / vn1;
+    rhat = un21 - q0 * vn1;
+
+    // q0 has at most error 2. No more than 2 iterations.
+    while q0 >= B || q0 * vn0 > B * rhat + un0 {
+        q0 -= 1;
+        rhat += vn1;
+        if rhat >= B {
+            break;
+        }
+    }
+
+    *r = (un21
+        .wrapping_mul(B)
+        .wrapping_add(un0)
+        .wrapping_sub(q0.wrapping_mul(v)))
+        >> s;
+    q1 * B + q0
+}
+
 pub fn udivmod4(
     res: &mut MaybeUninit<U256>,
     a: &U256,
@@ -25,218 +110,81 @@ pub fn udivmod4(
     }
 
     const N_UDWORD_BITS: u32 = 128;
-    const N_UTWORD_BITS: u32 = 256;
-    let n = a;
-    let d = b;
-    let mut q = MaybeUninit::<U256>::uninit();
-    let mut r = MaybeUninit::<U256>::uninit();
-    let mut sr: u32;
-    // special cases, X is unknown, K != 0
-    if *n.high() == 0 {
-        if *d.high() == 0 {
-            // 0 X
-            // ---
-            // 0 X
-            if let Some(rem) = rem {
-                set!(rem = U256::new(n.low() % d.low()));
-            }
-            set!(res = U256::new(n.low() / d.low()));
-            return;
-        }
-        // 0 X
-        // ---
-        // K X
+
+    let mut dividend = *a;
+    let mut divisor = *b;
+    let mut quotient: U256;
+    let mut remainder: U256;
+
+    if divisor > dividend {
         if let Some(rem) = rem {
-            set!(rem = U256::new(*n.low()));
+            set!(rem = dividend);
         }
         set!(res = U256::ZERO);
         return;
     }
-    // n.high() != 0
-    if *d.low() == 0 {
-        if *d.high() == 0 {
-            // K X
-            // ---
-            // 0 0
-            if let Some(rem) = rem {
-                set!(rem = U256::new(n.high() % d.low()));
-            }
-            set!(res = U256::new(n.high() / d.low()));
-            return;
-        }
-        // d.high() != 0
-        if *n.low() == 0 {
-            // K 0
-            // ---
-            // K 0
-            if let Some(rem) = rem {
-                set!(rem = U256::from_words(n.high() % d.high(), 0));
-            }
-            set!(res = U256::new(n.high() / d.high()));
-            return;
-        }
-        // K K
-        // ---
-        // K 0
-        // NOTE: Modified from `if (d.high() & (d.high() - 1)) == 0`
-        if d.high().is_power_of_two() {
-            /* if d is a power of 2 */
-            if let Some(rem) = rem {
-                set!(rem = U256::from_words(n.high() & (d.high() - 1), *n.low()));
-            }
-            set!(res = U256::new(n.high() >> d.high().trailing_zeros()));
-            return;
-        }
-        // K K
-        // ---
-        // K 0
-        sr = d
-            .high()
-            .leading_zeros()
-            .wrapping_sub(n.high().leading_zeros());
-        // 0 <= sr <= N_UDWORD_BITS - 2 or sr large
-        if sr > N_UDWORD_BITS - 2 {
-            if let Some(rem) = rem {
-                set!(rem = *n);
-            }
-            set!(res = U256::ZERO);
-            return;
-        }
-        sr += 1;
-        // 1 <= sr <= N_UDWORD_BITS - 1
-        // q.all = n.all << (N_UTWORD_BITS - sr);
-        set!(q = U256::from_words(n.low() << (N_UDWORD_BITS - sr), 0));
-        // r.all = n.all >> sr;
-        set!(
-            r = U256::from_words(
-                n.high() >> sr,
-                (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-            )
-        );
-    } else {
-        /* d.low() != 0 */
-        if *d.high() == 0 {
-            // K X
-            // ---
-            // 0 K
-            // NOTE: Modified from `if (d.low() & (d.low() - 1)) == 0`.
-            if d.low().is_power_of_two() {
-                /* if d is a power of 2 */
-                if let Some(rem) = rem {
-                    set!(rem = U256::new(n.low() & (d.low() - 1)));
-                }
-                if *d.low() == 1 {
-                    set!(res = *n);
-                    return;
-                }
-                sr = d.low().trailing_zeros();
-                set!(
-                    res = U256::from_words(
-                        n.high() >> sr,
-                        (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-                    )
-                );
-                return;
-            }
-            // K X
-            // ---
-            // 0 K
-            sr = 1 + N_UDWORD_BITS + d.low().leading_zeros() - (n.high()).leading_zeros();
-            // 2 <= sr <= N_UTWORD_BITS - 1
-            // q.all = n.all << (N_UTWORD_BITS - sr);
-            // r.all = n.all >> sr;
-            #[allow(clippy::comparison_chain)]
-            if sr == N_UDWORD_BITS {
-                set!(q = U256::from_words(*n.low(), 0));
-                set!(r = U256::from_words(0, *n.high()));
-            } else if sr < N_UDWORD_BITS {
-                /* 2 <= sr <= N_UDWORD_BITS - 1 */
-                set!(q = U256::from_words(n.low() << (N_UDWORD_BITS - sr), 0));
-                set!(
-                    r = U256::from_words(
-                        n.high() >> sr,
-                        (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-                    )
-                );
-            } else {
-                /* N_UDWORD_BITS + 1 <= sr <= N_UTWORD_BITS - 1 */
-                set!(
-                    q = U256::from_words(
-                        (n.high() << (N_UTWORD_BITS - sr)) | (n.low() >> (sr - N_UDWORD_BITS)),
-                        n.low() << (N_UTWORD_BITS - sr),
-                    )
-                );
-                set!(r = U256::from_words(0, n.high() >> (sr - N_UDWORD_BITS)));
-            }
+    // When the divisor fits in 128 bits, we can use an optimized path.
+    if *divisor.high() == 0 {
+        remainder = U256::ZERO;
+        if dividend.high() < divisor.low() {
+            // The result fits in 128 bits.
+            quotient = U256::from_words(
+                0,
+                udiv256_by_64_to_64(
+                    *dividend.high(),
+                    *dividend.low(),
+                    *divisor.low(),
+                    remainder.low_mut(),
+                ),
+            );
         } else {
-            // K X
-            // ---
-            // K K
-            sr = (d.high())
-                .leading_zeros()
-                .wrapping_sub((n.high()).leading_zeros());
-            // 0 <= sr <= N_UDWORD_BITS - 1 or sr large
-            if sr > N_UDWORD_BITS - 1 {
-                if let Some(rem) = rem {
-                    set!(rem = *n);
-                }
-                set!(res = U256::ZERO);
-                return;
-            }
-            sr += 1;
-            // 1 <= sr <= N_UDWORD_BITS
-            // q.all = n.all << (N_UTWORD_BITS - sr);
-            // r.all = n.all >> sr;
-            if sr == N_UDWORD_BITS {
-                set!(q = U256::from_words(*n.low(), 0));
-                set!(r = U256::from_words(0, *n.high()));
-            } else {
-                set!(
-                    r = U256::from_words(
-                        n.high() >> sr,
-                        (n.high() << (N_UDWORD_BITS - sr)) | (n.low() >> sr),
-                    )
-                );
-                set!(q = U256::from_words(n.low() << (N_UDWORD_BITS - sr), 0));
-            }
+            // First, divide with the high part to get the remainder in dividend.s.high.
+            // After that dividend.s.high < divisor.s.low.
+            let quotient_high = dividend.high() / divisor.low();
+            *dividend.high_mut() = dividend.high() % divisor.low();
+            quotient = U256::from_words(
+                quotient_high,
+                udiv256_by_64_to_64(
+                    *dividend.high(),
+                    *dividend.low(),
+                    *divisor.low(),
+                    remainder.low_mut(),
+                ),
+            );
         }
+        if let Some(rem) = rem {
+            set!(rem = remainder);
+        }
+        set!(res = quotient);
+        return;
     }
-    // Not a special case
-    // q and r are initialized with:
-    // q.all = n.all << (N_UTWORD_BITS - sr);
-    // r.all = n.all >> sr;
-    // 1 <= sr <= N_UTWORD_BITS - 1
-    let mut carry = 0u128;
-    let mut q = unsafe { q.assume_init() };
-    let mut r = unsafe { r.assume_init() };
-    while sr > 0 {
-        // r:q = ((r:q)  << 1) | carry
-        *r.high_mut() = (r.high() << 1) | (r.low() >> (N_UDWORD_BITS - 1));
-        *r.low_mut() = (r.low() << 1) | (q.high() >> (N_UDWORD_BITS - 1));
-        *q.high_mut() = (q.high() << 1) | (q.low() >> (N_UDWORD_BITS - 1));
-        *q.low_mut() = (q.low() << 1) | carry;
-        // carry = 0;
-        // if (r.all >= d.all)
-        // {
-        //     r.all -= d.all;
-        //      carry = 1;
-        // }
-        // NOTE: Modified from `(d - r - 1) >> (N_UTWORD_BITS - 1)` to be an
-        // **arithmetic** shift.
-        let s = {
-            let (hi, _) = d.wrapping_sub(r).wrapping_sub(U256::ONE).into_words();
-            ((hi as i128) >> 127).as_u256()
-        };
-        carry = s.low() & 1;
-        r -= d & s;
 
-        sr -= 1;
+    // 0 <= shift <= 127.
+    let shift = divisor.high().leading_zeros() - dividend.high().leading_zeros();
+
+    divisor <<= shift;
+    quotient = U256::ZERO;
+    for _ in 0..=shift {
+        *quotient.low_mut() <<= 1;
+        // Branch free version of.
+        // if (dividend.all >= divisor.all)
+        // {
+        //    dividend.all -= divisor.all;
+        //    carry = 1;
+        // }
+        let s = ((*divisor
+            .wrapping_sub(dividend)
+            .wrapping_sub(U256::ONE)
+            .high() as i128)
+            >> (N_UDWORD_BITS - 1)) as u128;
+        *quotient.low_mut() |= s & 1;
+        dividend -= divisor & U256::from_words(s, s);
+        divisor >>= 1;
     }
-    q = (q << 1) | U256::new(carry);
     if let Some(rem) = rem {
-        set!(rem = r);
+        set!(rem = dividend);
     }
-    set!(res = q);
+    set!(res = quotient);
 }
 
 pub fn div2(r: &mut U256, a: &U256) {
@@ -268,6 +216,7 @@ pub fn rem3(r: &mut MaybeUninit<U256>, a: &U256, b: &U256) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AsU256;
 
     fn div(a: impl AsU256, b: impl AsU256) -> U256 {
         let mut r = MaybeUninit::uninit();


### PR DESCRIPTION
See #2 for the original improvement proposal. It appears the issue was indeed with the computation of `s`. Just creating this PR as a reference.

Here are the benchmarks.
![image](https://user-images.githubusercontent.com/4210206/108537351-cd249e00-72dd-11eb-803c-e4b227b3f87a.png)


Indeed there is MUCH improved latency when computing `XX / 0X` style divisions. The other cases seemed to have regressed in performance. Most notably the `0X/0X` case, which I would argue is likely the most common being used. Maybe an additional fast-path for this case might help considerably.

<details><summary>Unscientific benchmarks</summary>

```diff
diff --git a/bench/benches/num.rs b/bench/benches/num.rs
index c2074fd..d47e969 100644
--- a/bench/benches/num.rs
+++ b/bench/benches/num.rs
@@ -4,14 +4,27 @@ use std::ops::*;
 
 fn arithmetic<U>(c: &mut Criterion)
 where
-    U: Add + Mul + Sub + Shl<Output = U> + Shr + Copy + From<u128>,
+    U: Add + Div + Mul + Sub + Shl<Output = U> + Shr + Copy + From<u128>,
 {
     let value = U::from(u128::MAX) << U::from(11);
+    let lo = U::from(u128::MAX >> 13);
 
     c.bench_function(&format!("{}::add", any::type_name::<U>()), |b| {
         b.iter(|| black_box(value) + black_box(value))
     });
 
+    c.bench_function(&format!("{}::div (lo/lo)", any::type_name::<U>()), |b| {
+        b.iter(|| black_box(lo) / black_box(lo))
+    });
+
+    c.bench_function(&format!("{}::div (hi/lo)", any::type_name::<U>()), |b| {
+        b.iter(|| black_box(value) / black_box(lo))
+    });
+
+    c.bench_function(&format!("{}::div (hi/hi)", any::type_name::<U>()), |b| {
+        b.iter(|| black_box(value) / black_box(value))
+    });
+
     c.bench_function(&format!("{}::mul", any::type_name::<U>()), |b| {
         b.iter(|| black_box(value) * black_box(value))
     });
```

<details>