### PR TITLE
Added `serde` feature and support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint
       run: |
-        cargo fmt -- --check
+        cargo fmt --all -- --check
         cargo clippy --workspace --all-targets -- -D warnings
     - name: Test Native Intrinsics
       run: |
@@ -25,5 +25,11 @@ jobs:
         cargo test --release
     - name: Test LLVM Intrinsics
       run: |
+        cargo clippy --features llvm-intrinsics --all-targets -- -D warnings
         cargo test --features llvm-intrinsics
         cargo test --features llvm-intrinsics --release
+    - name: Test Additional Features
+      run: |
+        cargo clippy --features serde --all-targets -- -D warnings
+        cargo test --features serde
+        cargo test --features serde --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethnum"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2021"
 description = "256-bit integer implementation"
@@ -20,7 +20,9 @@ members = [
 ]
 
 [features]
+default = ["serde"]
 llvm-intrinsics = ["ethnum-intrinsics"]
 
 [dependencies]
 ethnum-intrinsics = { version = "1", path = "intrinsics", optional = true }
+serde = { version = "1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["integer", "u256", "ethereum"]
 categories = ["cryptography::cryptocurrencies", "mathematics", "no-std"]
 
+[package.metadata.docs.rs]
+features = ["serde"]
+
 [workspace]
 members = [
   "bench",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ members = [
 ]
 
 [features]
-default = ["serde"]
 llvm-intrinsics = ["ethnum-intrinsics"]
 
 [dependencies]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Nicholas Rodrigues Lordello
+Copyright (c) 2020-2022 Nicholas Rodrigues Lordello
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -5,30 +5,38 @@
 //! implementation for primitive integer types:
 //! https://doc.rust-lang.org/src/core/fmt/num.rs.html
 
-use crate::{error, uint::U256};
+use crate::uint::U256;
 use core::{
-    fmt,
-    mem::MaybeUninit,
+    fmt::{self, Write},
+    mem::{self, MaybeUninit},
     num::{IntErrorKind, ParseIntError},
+    ops::{Add, Mul, Sub},
     ptr, slice, str,
 };
 
 #[doc(hidden)]
-pub(crate) trait FromStrRadixHelper: PartialOrd + Copy {
-    fn min_value() -> Self;
-    fn max_value() -> Self;
+pub(crate) trait FromStrRadixHelper:
+    PartialOrd + Copy + Add<Output = Self> + Sub<Output = Self> + Mul<Output = Self>
+{
+    const MIN: Self;
     fn from_u32(u: u32) -> Self;
     fn checked_mul(&self, other: u32) -> Option<Self>;
     fn checked_sub(&self, other: u32) -> Option<Self>;
     fn checked_add(&self, other: u32) -> Option<Self>;
 }
 
+#[inline(always)]
+fn can_not_overflow<T>(radix: u32, is_signed_ty: bool, digits: &[u8]) -> bool {
+    radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize
+}
+
 pub(crate) fn from_str_radix<T: FromStrRadixHelper>(
     src: &str,
     radix: u32,
+    prefix: Option<&str>,
 ) -> Result<T, ParseIntError> {
-    use self::error::pie;
     use self::IntErrorKind::*;
+    use crate::error::pie;
 
     assert!(
         (2..=36).contains(&radix),
@@ -40,7 +48,7 @@ pub(crate) fn from_str_radix<T: FromStrRadixHelper>(
         return Err(pie(Empty));
     }
 
-    let is_signed_ty = T::from_u32(0) > T::min_value();
+    let is_signed_ty = T::from_u32(0) > T::MIN;
 
     // all valid digits are ascii, so we will just iterate over the utf8 bytes
     // and cast them to chars. .to_digit() will safely return None for anything
@@ -48,7 +56,7 @@ pub(crate) fn from_str_radix<T: FromStrRadixHelper>(
     // of multi-byte sequences
     let src = src.as_bytes();
 
-    let (is_positive, digits) = match src[0] {
+    let (is_positive, prefixed_digits) = match src[0] {
         b'+' | b'-' if src[1..].is_empty() => {
             return Err(pie(InvalidDigit));
         }
@@ -57,48 +65,77 @@ pub(crate) fn from_str_radix<T: FromStrRadixHelper>(
         _ => (true, src),
     };
 
+    let digits = match prefix {
+        Some(prefix) => prefixed_digits
+            .strip_prefix(prefix.as_bytes())
+            .ok_or(pie(InvalidDigit))?,
+        None => prefixed_digits,
+    };
+
     let mut result = T::from_u32(0);
-    if is_positive {
-        // The number is positive
-        for &c in digits {
-            let x = match (c as char).to_digit(radix) {
-                Some(x) => x,
-                None => return Err(pie(InvalidDigit)),
-            };
-            result = match result.checked_mul(radix) {
-                Some(result) => result,
-                None => return Err(pie(PosOverflow)),
-            };
-            result = match result.checked_add(x) {
-                Some(result) => result,
-                None => return Err(pie(PosOverflow)),
+
+    if can_not_overflow::<T>(radix, is_signed_ty, digits) {
+        // If the len of the str is short compared to the range of the type
+        // we are parsing into, then we can be certain that an overflow will not occur.
+        // This bound is when `radix.pow(digits.len()) - 1 <= T::MAX` but the condition
+        // above is a faster (conservative) approximation of this.
+        //
+        // Consider radix 16 as it has the highest information density per digit and will thus overflow the earliest:
+        // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
+        // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
+        macro_rules! run_unchecked_loop {
+            ($unchecked_additive_op:expr) => {
+                for &c in digits {
+                    result = result * T::from_u32(radix);
+                    let x = (c as char).to_digit(radix).ok_or(pie(InvalidDigit))?;
+                    result = $unchecked_additive_op(result, T::from_u32(x));
+                }
             };
         }
+        if is_positive {
+            run_unchecked_loop!(<T as core::ops::Add>::add)
+        } else {
+            run_unchecked_loop!(<T as core::ops::Sub>::sub)
+        };
     } else {
-        // The number is negative
-        for &c in digits {
-            let x = match (c as char).to_digit(radix) {
-                Some(x) => x,
-                None => return Err(pie(InvalidDigit)),
-            };
-            result = match result.checked_mul(radix) {
-                Some(result) => result,
-                None => return Err(pie(NegOverflow)),
-            };
-            result = match result.checked_sub(x) {
-                Some(result) => result,
-                None => return Err(pie(NegOverflow)),
+        macro_rules! run_checked_loop {
+            ($checked_additive_op:ident, $overflow_err:expr) => {
+                for &c in digits {
+                    // When `radix` is passed in as a literal, rather than doing a slow `imul`
+                    // the compiler can use shifts if `radix` can be expressed as a
+                    // sum of powers of 2 (x*10 can be written as x*8 + x*2).
+                    // When the compiler can't use these optimisations,
+                    // the latency of the multiplication can be hidden by issuing it
+                    // before the result is needed to improve performance on
+                    // modern out-of-order CPU as multiplication here is slower
+                    // than the other instructions, we can get the end result faster
+                    // doing multiplication first and let the CPU spends other cycles
+                    // doing other computation and get multiplication result later.
+                    let mul = result.checked_mul(radix);
+                    let x = (c as char).to_digit(radix).ok_or(pie(InvalidDigit))?;
+                    result = mul.ok_or_else($overflow_err)?;
+                    result = T::$checked_additive_op(&result, x).ok_or_else($overflow_err)?;
+                }
             };
         }
+        if is_positive {
+            run_checked_loop!(checked_add, || pie(PosOverflow))
+        } else {
+            run_checked_loop!(checked_sub, || pie(NegOverflow))
+        };
     }
     Ok(result)
+}
+
+pub(crate) fn from_str_prefixed<T: FromStrRadixHelper>(src: &str) -> Result<T, ParseIntError> {
+    from_str_radix(src, 16, Some("0x")).or_else(|_| from_str_radix(src, 10, None))
 }
 
 pub(crate) trait GenericRadix: Sized {
     const BASE: u8;
     const PREFIX: &'static str;
     fn digit(x: u8) -> u8;
-    fn fmt_u256(&self, mut x: U256, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt_u256(&self, mut x: U256, is_nonnegative: bool, f: &mut fmt::Formatter) -> fmt::Result {
         // The radix can be as low as 2, so we need a buffer of at least 256
         // characters for a base 2 number.
         let zero = U256::ZERO;
@@ -126,7 +163,7 @@ pub(crate) trait GenericRadix: Sized {
                 buf.len(),
             ))
         };
-        f.pad_integral(true, Self::PREFIX, buf)
+        f.pad_integral(is_nonnegative, Self::PREFIX, buf)
     }
 }
 
@@ -237,36 +274,156 @@ pub(crate) fn fmt_u256(mut n: U256, is_nonnegative: bool, f: &mut fmt::Formatter
     f.pad_integral(is_nonnegative, "", buf_slice)
 }
 
+/// A stack-allocated buffer that can be used for writing formatted strings.
+///
+/// This allows us to leverage existing `fmt` implementations on integer types
+/// without requiring heap allocations (i.e. writing to a `String` buffer).
+pub(crate) struct FormatBuffer<const N: usize> {
+    offset: usize,
+    buffer: [MaybeUninit<u8>; N],
+}
+
+impl<const N: usize> FormatBuffer<N> {
+    /// Creates a new formatting buffer.
+    pub(crate) fn new() -> Self {
+        Self {
+            offset: 0,
+            buffer: [MaybeUninit::uninit(); N],
+        }
+    }
+
+    /// Returns a `str` to the currently written data.
+    pub(crate) fn as_str(&self) -> &str {
+        // SAFETY: We only ever write valid UTF-8 strings to the buffer, so the
+        // resulting string will always be valid.
+        unsafe {
+            let buffer = slice::from_raw_parts(self.buffer[0].as_ptr(), self.offset);
+            str::from_utf8_unchecked(buffer)
+        }
+    }
+}
+
+impl FormatBuffer<78> {
+    /// Allocates a formatting buffer large enough to hold any possible decimal
+    /// encoded 256-bit value.
+    pub(crate) fn decimal() -> Self {
+        Self::new()
+    }
+}
+
+impl FormatBuffer<67> {
+    /// Allocates a formatting buffer large enough to hold any possible
+    /// hexadecimal encoded 256-bit value.
+    pub(crate) fn hex() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> Write for FormatBuffer<N> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let end = self.offset.checked_add(s.len()).ok_or(fmt::Error)?;
+
+        // Make sure there is enough space in the buffer.
+        if end > N {
+            return Err(fmt::Error);
+        }
+
+        // SAFETY: We checked that there is enough space in the buffer to fit
+        // the string `s` starting from `offset`, and the pointers cannot be
+        // overlapping because of Rust ownership semantics (i.e. `s` cannot
+        // overlap with `buffer` because we have a mutable reference to `self`
+        // and by extension `buffer`).
+        unsafe {
+            let buffer = self.buffer[0].as_mut_ptr().add(self.offset);
+            ptr::copy_nonoverlapping(s.as_ptr(), buffer, s.len());
+        }
+        self.offset = end;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::int::I256;
+    use alloc::{
+        boxed::Box,
+        fmt::{Display, LowerHex},
+        format,
+    };
+
+    #[test]
+    fn from_str_prefixed() {
+        assert_eq!(from_str_radix::<U256>("0b101", 2, Some("0b")).unwrap(), 5);
+        assert_eq!(from_str_radix::<I256>("-0xf", 16, Some("0x")).unwrap(), -15);
+    }
 
     #[test]
     fn from_str_errors() {
         assert_eq!(
-            from_str_radix::<U256>("", 2).unwrap_err().kind(),
+            from_str_radix::<U256>("", 2, None).unwrap_err().kind(),
             &IntErrorKind::Empty,
         );
         assert_eq!(
-            from_str_radix::<U256>("?", 2).unwrap_err().kind(),
+            from_str_radix::<U256>("?", 2, None).unwrap_err().kind(),
             &IntErrorKind::InvalidDigit,
         );
         assert_eq!(
-            from_str_radix::<U256>("-1", 10).unwrap_err().kind(),
-            &IntErrorKind::InvalidDigit,
-        );
-        assert_eq!(
-            from_str_radix::<U256>("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", 36)
+            from_str_radix::<U256>("1", 16, Some("0x"))
                 .unwrap_err()
                 .kind(),
+            &IntErrorKind::InvalidDigit,
+        );
+        assert_eq!(
+            from_str_radix::<U256>("-1", 10, None).unwrap_err().kind(),
+            &IntErrorKind::InvalidDigit,
+        );
+        assert_eq!(
+            from_str_radix::<U256>(
+                "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+                36,
+                None
+            )
+            .unwrap_err()
+            .kind(),
             &IntErrorKind::PosOverflow,
         );
         assert_eq!(
-            from_str_radix::<I256>("-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", 36)
-                .unwrap_err()
-                .kind(),
+            from_str_radix::<I256>(
+                "-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+                36,
+                None
+            )
+            .unwrap_err()
+            .kind(),
             &IntErrorKind::NegOverflow,
         );
+    }
+
+    #[test]
+    fn formatting_buffer() {
+        for value in [
+            Box::new(I256::MIN) as Box<dyn Display>,
+            Box::new(I256::MAX),
+            Box::new(U256::MIN),
+            Box::new(U256::MAX),
+        ] {
+            let mut f = FormatBuffer::decimal();
+            write!(f, "{value}").unwrap();
+            assert_eq!(f.as_str(), format!("{value}"));
+        }
+
+        for value in [
+            Box::new(I256::MIN) as Box<dyn LowerHex>,
+            Box::new(I256::MAX),
+            Box::new(U256::MIN),
+            Box::new(U256::MAX),
+        ] {
+            let mut f = FormatBuffer::hex();
+            let value = &*value;
+            write!(f, "{value:-#x}").unwrap();
+            assert_eq!(f.as_str(), format!("{value:-#x}"));
+        }
     }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,7 +3,8 @@
 //!
 //! Most of these implementations were ported from the Rust standard library's
 //! implementation for primitive integer types:
-//! https://doc.rust-lang.org/src/core/fmt/num.rs.html
+//! <https://doc.rust-lang.org/src/core/num/mod.rs.html>
+//! <https://doc.rust-lang.org/src/core/fmt/num.rs.html>
 
 use crate::uint::U256;
 use core::{

--- a/src/int.rs
+++ b/src/int.rs
@@ -9,6 +9,7 @@ mod ops;
 
 pub use self::convert::AsI256;
 use crate::uint::U256;
+use core::num::ParseIntError;
 
 /// A 256-bit signed integer type.
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -110,6 +111,49 @@ impl I256 {
         {
             &mut self.0[0]
         }
+    }
+
+    /// Converts a prefixed string slice in base 16 to an integer.
+    ///
+    /// The string is expected to be an optional `+` or `-` sign followed by
+    /// the `0x` prefix and finally the digits. Leading and trailing whitespace
+    /// represent an error.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use ethnum::I256;
+    /// assert_eq!(I256::from_str_hex("0x2A"), Ok(I256::new(42)));
+    /// assert_eq!(I256::from_str_hex("-0xa"), Ok(I256::new(-10)));
+    /// ```
+    pub fn from_str_hex(src: &str) -> Result<Self, ParseIntError> {
+        crate::fmt::from_str_radix(src, 16, Some("0x"))
+    }
+
+    /// Converts a prefixed string slice in a base determined by the prefix to
+    /// an integer.
+    ///
+    /// The string is expected to be an optional `+` or `-` sign followed by
+    /// the one of the supported prefixes and finally the digits. Leading and
+    /// trailing whitespace represent an error. The base is dertermined based
+    /// on the prefix:
+    ///
+    /// * `0x`: base `16`
+    /// * no prefix: base `10`
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use ethnum::I256;
+    /// assert_eq!(I256::from_str_prefixed("42"), Ok(I256::new(42)));
+    /// assert_eq!(I256::from_str_prefixed("-0xa"), Ok(I256::new(-10)));
+    /// ```
+    pub fn from_str_prefixed(src: &str) -> Result<Self, ParseIntError> {
+        crate::fmt::from_str_prefixed(src)
     }
 
     /// Cast to a primitive `i8`.

--- a/src/int/api.rs
+++ b/src/int/api.rs
@@ -73,7 +73,7 @@ impl I256 {
     /// assert_eq!(I256::from_str_radix("A", 16), Ok(I256::new(10)));
     /// ```
     pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-        fmt::from_str_radix(src, radix)
+        fmt::from_str_radix(src, radix, None)
     }
 
     /// Returns the number of ones in the binary representation of `self`.

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,13 +1,10 @@
-//! This module contains intrinsics used by the [`I256`] abd [`U256`]
-//! implementations.
+//! This module contains intrinsics used by the [`I256`](struct@crate::I256) and
+//! [`U256`](struct@crate::U256) implementations.
 //!
 //! # Stability
 //!
 //! Be careful when using these intrinsics directly. Semantic versioning API
 //! compatibility is **not guaranteed** for any of these intrinsics.
-//!
-//! [`I256`]: struct.I256.html
-//! [`U256`]: struct.U256.html
 
 #![allow(missing_docs)]
 

--- a/src/intrinsics/native/divmod.rs
+++ b/src/intrinsics/native/divmod.rs
@@ -6,8 +6,8 @@
 //! 256-bit division.
 //!
 //! This source is ported from LLVM project from C:
-//! - signed division: https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/divmodti4.c
-//! - unsigned division: https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/udivmodti4.c
+//! - signed division: <https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/divmodti4.c>
+//! - unsigned division: <https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/udivmodti4.c>
 
 use crate::{int::I256, uint::U256};
 use core::mem::MaybeUninit;

--- a/src/intrinsics/native/divmod.rs
+++ b/src/intrinsics/native/divmod.rs
@@ -20,10 +20,8 @@ fn udiv256_by_128_to_128(u1: u128, u0: u128, mut v: u128, r: &mut u128) -> u128 
     let (vn1, vn0): (u128, u128); // Norm. divisor digits
     let (mut q1, mut q0): (u128, u128); // Quotient digits
     let (un128, un21, un10): (u128, u128, u128); // Dividend digit pairs
-    let mut rhat: u128; // A remainder
-    let s: u32; // Shift amount for normalization
 
-    s = v.leading_zeros();
+    let s = v.leading_zeros();
     if s > 0 {
         // Normalize the divisor.
         v <<= s;
@@ -45,7 +43,7 @@ fn udiv256_by_128_to_128(u1: u128, u0: u128, mut v: u128, r: &mut u128) -> u128 
 
     // Compute the first quotient digit, q1.
     q1 = un128 / vn1;
-    rhat = un128 - q1 * vn1;
+    let mut rhat = un128 - q1 * vn1;
 
     // q1 has at most error 2. No more than 2 iterations.
     while q1 >= B || q1 * vn0 > B * rhat + un1 {

--- a/src/intrinsics/native/mul.rs
+++ b/src/intrinsics/native/mul.rs
@@ -12,18 +12,15 @@ use core::mem::MaybeUninit;
 
 #[inline]
 pub fn umulddi3(a: &u128, b: &u128) -> U256 {
-    let mut high;
-    let mut low;
-
     const BITS_IN_DWORD_2: u32 = 64;
     const LOWER_MASK: u128 = u128::MAX >> BITS_IN_DWORD_2;
 
-    low = (a & LOWER_MASK) * (b & LOWER_MASK);
+    let mut low = (a & LOWER_MASK) * (b & LOWER_MASK);
     let mut t = low >> BITS_IN_DWORD_2;
     low &= LOWER_MASK;
     t += (a >> BITS_IN_DWORD_2) * (b & LOWER_MASK);
     low += (t & LOWER_MASK) << BITS_IN_DWORD_2;
-    high = t >> BITS_IN_DWORD_2;
+    let mut high = t >> BITS_IN_DWORD_2;
     t = low >> BITS_IN_DWORD_2;
     low &= LOWER_MASK;
     t += (b >> BITS_IN_DWORD_2) * (a & LOWER_MASK);

--- a/src/intrinsics/native/mul.rs
+++ b/src/intrinsics/native/mul.rs
@@ -5,7 +5,7 @@
 //! information in order to implement 256-bit overflowing multiplication.
 //!
 //! This source is ported from LLVM project from C:
-//! https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/multi3.c
+//! <https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/multi3.c>
 
 use crate::{int::I256, uint::U256};
 use core::mem::MaybeUninit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,13 @@ mod uint;
 
 /// Convenience re-export of 256-integer types and as- conversion traits.
 pub mod prelude {
-    pub use crate::int::{AsI256, I256};
-    pub use crate::uint::{AsU256, U256};
+    pub use crate::{AsI256, AsU256, I256, U256};
 }
 
-pub use self::prelude::*;
+pub use crate::{
+    int::{AsI256, I256},
+    uint::{AsU256, U256},
+};
 
 /// A 256-bit signed integer type.
 #[allow(non_camel_case_types)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ mod error;
 mod fmt;
 mod int;
 pub mod intrinsics;
+#[cfg(feature = "serde")]
+pub mod serde;
 mod uint;
 
 /// Convenience re-export of 256-integer types and as- conversion traits.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,452 @@
+//! Serde serialization implementation for 256-bit integer types.
+//!
+//! This implementation is very JSON-centric in that it serializes the integer
+//! types as `QUANTITIES` as specified in the Ethereum RPC. That is, integers
+//! are encoded as `"0x"` prefixed strings without extrenuous leading `0`s. For
+//! negative signed integers, the string is prefixed with a `"-"` sign.
+//!
+//! Note that this module contains alternative serialization schemes that can
+//! be used with `#[serde(with = "...")]`.
+//!
+//! TODO(nlordell): example!
+
+use crate::{fmt::FormatBuffer, I256, U256};
+use core::{
+    fmt::{self, Display, Formatter, Write},
+    str,
+};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+impl Serialize for I256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut f = FormatBuffer::hex();
+        write!(f, "{self:-#x}").expect("unexpected formatting failure");
+        serializer.serialize_str(f.as_str())
+    }
+}
+
+impl Serialize for U256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut f = FormatBuffer::hex();
+        write!(f, "{self:#x}").expect("unexpected formatting failure");
+        serializer.serialize_str(f.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for I256 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FormatVisitor(Self::from_str_hex))
+    }
+}
+
+impl<'de> Deserialize<'de> for U256 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FormatVisitor(Self::from_str_hex))
+    }
+}
+
+/// Module for use with `#[serde(with = "ethnum::serde::decimal")]` to specify
+/// decimal string serialization for 256-bit integer types.
+pub mod decimal {
+    use super::*;
+    use core::num::ParseIntError;
+
+    #[doc(hidden)]
+    pub trait Decimal: Sized {
+        fn from_str_decimal(src: &str) -> Result<Self, ParseIntError>;
+        fn write_decimal(&self, f: &mut impl Write);
+    }
+
+    impl Decimal for I256 {
+        fn from_str_decimal(src: &str) -> Result<Self, ParseIntError> {
+            Self::from_str_radix(src, 10)
+        }
+        fn write_decimal(&self, f: &mut impl Write) {
+            write!(f, "{self}").expect("unexpected formatting error")
+        }
+    }
+
+    impl Decimal for U256 {
+        fn from_str_decimal(src: &str) -> Result<Self, ParseIntError> {
+            Self::from_str_radix(src, 10)
+        }
+        fn write_decimal(&self, f: &mut impl Write) {
+            write!(f, "{self}").expect("unexpected formatting error")
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Decimal,
+        S: Serializer,
+    {
+        let mut f = FormatBuffer::decimal();
+        value.write_decimal(&mut f);
+        serializer.serialize_str(f.as_str())
+    }
+
+    #[doc(hidden)]
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Decimal,
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FormatVisitor(T::from_str_decimal))
+    }
+}
+
+/// Module for use with `#[serde(with = "ethnum::serde::prexied")]` to specify
+/// prefixed string serialization for 256-bit integer types.
+///
+/// This allows serialization to look for an optional `0x` prefix to determine
+/// if it is a hexadecimal string or decimal string.
+pub mod prefixed {
+    use super::*;
+    use core::num::ParseIntError;
+
+    #[doc(hidden)]
+    pub trait Prefixed: Serialize + Sized {
+        fn from_str_prefixed(src: &str) -> Result<Self, ParseIntError>;
+    }
+
+    impl Prefixed for I256 {
+        fn from_str_prefixed(src: &str) -> Result<Self, ParseIntError> {
+            Self::from_str_prefixed(src)
+        }
+    }
+
+    impl Prefixed for U256 {
+        fn from_str_prefixed(src: &str) -> Result<Self, ParseIntError> {
+            Self::from_str_prefixed(src)
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Prefixed,
+        S: Serializer,
+    {
+        value.serialize(serializer)
+    }
+
+    #[doc(hidden)]
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Prefixed,
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FormatVisitor(T::from_str_prefixed))
+    }
+}
+
+/// Internal visitor struct implementation to facilitate implementing different
+/// serialization formats.
+struct FormatVisitor<F>(F);
+
+impl<'de, T, E, F> Visitor<'de> for FormatVisitor<F>
+where
+    E: Display,
+    F: FnOnce(&str) -> Result<T, E>,
+{
+    type Value = T;
+
+    fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str("a formatted 256-bit integer")
+    }
+
+    fn visit_str<E_>(self, v: &str) -> Result<Self::Value, E_>
+    where
+        E_: de::Error,
+    {
+        self.0(v).map_err(de::Error::custom)
+    }
+
+    fn visit_bytes<E_>(self, v: &[u8]) -> Result<Self::Value, E_>
+    where
+        E_: de::Error,
+    {
+        let string = str::from_utf8(v)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))?;
+        self.visit_str(string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+    use serde::{
+        de::value::{self, BorrowedStrDeserializer},
+        ser::Impossible,
+    };
+
+    #[test]
+    fn serialize_integers() {
+        macro_rules! ser {
+            ($method:expr, $value:expr) => {{
+                let value = $value;
+                ($method)(&value, StringSerializer).unwrap()
+            }};
+        }
+
+        assert_eq!(
+            ser!(I256::serialize, I256::MIN),
+            "-0x8000000000000000000000000000000000000000000000000000000000000000",
+        );
+        assert_eq!(ser!(I256::serialize, I256::new(-1)), "-0x1");
+        assert_eq!(ser!(I256::serialize, I256::new(0)), "0x0");
+        assert_eq!(ser!(I256::serialize, I256::new(42)), "0x2a");
+
+        assert_eq!(ser!(U256::serialize, U256::new(0)), "0x0");
+        assert_eq!(ser!(U256::serialize, U256::new(4919)), "0x1337");
+        assert_eq!(
+            ser!(U256::serialize, U256::MAX),
+            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        );
+
+        assert_eq!(
+            ser!(decimal::serialize, I256::MIN),
+            "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+        );
+        assert_eq!(ser!(decimal::serialize, I256::new(-1)), "-1");
+        assert_eq!(ser!(decimal::serialize, I256::new(0)), "0");
+        assert_eq!(ser!(decimal::serialize, I256::new(42)), "42");
+
+        assert_eq!(ser!(decimal::serialize, U256::new(0)), "0");
+        assert_eq!(ser!(decimal::serialize, U256::new(4919)), "4919");
+        assert_eq!(
+            ser!(decimal::serialize, U256::MAX),
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        );
+    }
+
+    #[test]
+    fn deserialize_integers() {
+        macro_rules! de {
+            ($method:expr, $src:literal) => {{
+                let deserializer = BorrowedStrDeserializer::<value::Error>::new($src);
+                ($method)(deserializer).unwrap()
+            }};
+        }
+
+        assert_eq!(
+            de!(
+                I256::deserialize,
+                "-0x8000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            I256::MIN
+        );
+        assert_eq!(de!(I256::deserialize, "-0x1337"), I256::new(-4919));
+        assert_eq!(de!(I256::deserialize, "0x0"), I256::new(0));
+        assert_eq!(de!(I256::deserialize, "0x2a"), I256::new(42));
+        assert_eq!(de!(I256::deserialize, "0x2A"), I256::new(42));
+
+        assert_eq!(de!(U256::deserialize, "0x0"), U256::new(0));
+        assert_eq!(de!(U256::deserialize, "0x2a"), U256::new(42));
+        assert_eq!(de!(U256::deserialize, "0x2A"), U256::new(42));
+        assert_eq!(
+            de!(
+                U256::deserialize,
+                "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            ),
+            U256::MAX
+        );
+
+        assert_eq!(
+            de!(
+                decimal::deserialize::<I256, _>,
+                "-57896044618658097711785492504343953926634992332820282019728792003956564819968"
+            ),
+            I256::MIN
+        );
+        assert_eq!(de!(decimal::deserialize::<I256, _>, "-1"), I256::new(-1));
+        assert_eq!(de!(decimal::deserialize::<I256, _>, "0"), I256::new(0));
+        assert_eq!(de!(decimal::deserialize::<I256, _>, "42"), I256::new(42));
+
+        assert_eq!(de!(decimal::deserialize::<U256, _>, "0"), U256::new(0));
+        assert_eq!(de!(decimal::deserialize::<U256, _>, "42"), U256::new(42));
+        assert_eq!(
+            de!(
+                decimal::deserialize::<U256, _>,
+                "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            ),
+            U256::MAX
+        );
+
+        assert_eq!(de!(prefixed::deserialize::<I256, _>, "-1"), I256::new(-1));
+        assert_eq!(de!(prefixed::deserialize::<I256, _>, "-0x1"), I256::new(-1));
+        assert_eq!(de!(prefixed::deserialize::<I256, _>, "42"), I256::new(42));
+        assert_eq!(de!(prefixed::deserialize::<I256, _>, "0x2a"), I256::new(42));
+        assert_eq!(de!(prefixed::deserialize::<I256, _>, "0x2A"), I256::new(42));
+
+        assert_eq!(de!(prefixed::deserialize::<U256, _>, "42"), U256::new(42));
+        assert_eq!(de!(prefixed::deserialize::<U256, _>, "0x2a"), U256::new(42));
+        assert_eq!(de!(prefixed::deserialize::<U256, _>, "0x2A"), U256::new(42));
+    }
+
+    /// A string serializer used for testing.
+    struct StringSerializer;
+
+    impl Serializer for StringSerializer {
+        type Ok = String;
+        type Error = fmt::Error;
+        type SerializeSeq = Impossible<String, fmt::Error>;
+        type SerializeTuple = Impossible<String, fmt::Error>;
+        type SerializeTupleStruct = Impossible<String, fmt::Error>;
+        type SerializeTupleVariant = Impossible<String, fmt::Error>;
+        type SerializeMap = Impossible<String, fmt::Error>;
+        type SerializeStruct = Impossible<String, fmt::Error>;
+        type SerializeStructVariant = Impossible<String, fmt::Error>;
+        fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+            Ok(v.into())
+        }
+        fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+        where
+            T: Serialize,
+        {
+            unimplemented!()
+        }
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_unit_variant(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_newtype_struct<T: ?Sized>(
+            self,
+            _: &'static str,
+            _: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: Serialize,
+        {
+            unimplemented!()
+        }
+        fn serialize_newtype_variant<T: ?Sized>(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+            _: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: Serialize,
+        {
+            unimplemented!()
+        }
+        fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_tuple_struct(
+            self,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_tuple_variant(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_struct(
+            self,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            unimplemented!()
+        }
+        fn serialize_struct_variant(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            unimplemented!()
+        }
+        fn collect_str<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
+        where
+            T: Display + ?Sized,
+        {
+            todo!()
+        }
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -112,7 +112,7 @@ pub mod decimal {
     }
 }
 
-/// Module for use with `#[serde(with = "ethnum::serde::prexied")]` to specify
+/// Module for use with `#[serde(with = "ethnum::serde::prefixed")]` to specify
 /// prefixed string serialization for 256-bit integer types.
 ///
 /// This allows serialization to look for an optional `0x` prefix to determine

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -9,6 +9,7 @@ mod ops;
 
 pub use self::convert::AsU256;
 use crate::I256;
+use core::num::ParseIntError;
 
 /// A 256-bit unsigned integer type.
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -108,6 +109,48 @@ impl U256 {
         {
             &mut self.0[0]
         }
+    }
+
+    /// Converts a prefixed string slice in base 16 to an integer.
+    ///
+    /// The string is expected to be an optional `+` sign followed by the `0x`
+    /// prefix and finally the digits. Leading and trailing whitespace represent
+    /// an error.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use ethnum::U256;
+    /// assert_eq!(U256::from_str_hex("0x2A"), Ok(U256::new(42)));
+    /// ```
+    pub fn from_str_hex(src: &str) -> Result<Self, ParseIntError> {
+        crate::fmt::from_str_radix(src, 16, Some("0x"))
+    }
+
+    /// Converts a prefixed string slice in a base determined by the prefix to
+    /// an integer.
+    ///
+    /// The string is expected to be an optional `+` sign followed by the one of
+    /// the supported prefixes and finally the digits. Leading and trailing
+    /// whitespace represent an error. The base is dertermined based on the
+    /// prefix:
+    ///
+    /// * `0x`: base `16`
+    /// * no prefix: base `10`
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use ethnum::U256;
+    /// assert_eq!(U256::from_str_prefixed("42"), Ok(U256::new(42)));
+    /// assert_eq!(U256::from_str_prefixed("0xa"), Ok(U256::new(10)));
+    /// ```
+    pub fn from_str_prefixed(src: &str) -> Result<Self, ParseIntError> {
+        crate::fmt::from_str_prefixed(src)
     }
 
     /// Cast to a primitive `i8`.

--- a/src/uint/api.rs
+++ b/src/uint/api.rs
@@ -70,7 +70,7 @@ impl U256 {
     /// ```
     #[inline]
     pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-        fmt::from_str_radix(src, radix)
+        fmt::from_str_radix(src, radix, None)
     }
 
     /// Returns the number of ones in the binary representation of `self`.


### PR DESCRIPTION
This PR adds `serde` feature to the `ethnum` crate for adding `serde` serialization and deserialization support to both signed and unsigned integer types. The default serialization implementation encodes/decodes `0x`-prefixed hexadecimal strings.

Additionally, new convenience conversion methods were added for parsing integers from optionally prefixed strings (so parsing `0x2a` and `42` to the same value) as well as modules for use with `#[serde(with = "...")]` for much the same purpose.

For example:
```rust
#[derive(Serialize, Deserialize)]
struct Foo {
    #[serde(with = "ethnum::serde::prefixed")]
    value: U256,
}
```

would allow serializing the following JSON documents:
```js
{ "value": "0x2a" }
{ "value": "42" }
```

Finally, the hex, octal and binary formatting implementation supports the `-` formatting flag now. For rust standard integer types:
```rust
assert_eq!(format!("{:#x}", -10_i16), "0xfff6");
```

This means, there is no way to print a sign when formatting in a non-decimal radix. So for `I256`, support was added so that you can write:
```rust
assert_eq!(format!("{:-#x}", I256::new(-10)), "-0xa");
```

Note that the `{:#x}` format specifier still behaves the same way as they do for primitive integer types (i.e. sign-extended 2's complement).