### PR TITLE
Adds Mixed Integer Ops

### DIFF
--- a/src/int/api.rs
+++ b/src/int/api.rs
@@ -452,7 +452,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(1).checked_add_unsigned(U256::new(2)), Some(I256::new(3)));
     /// assert_eq!((I256::MAX - 2).checked_add_unsigned(U256::new(3)), None);
     /// ```
@@ -461,7 +462,11 @@ impl I256 {
     #[inline]
     pub fn checked_add_unsigned(self, rhs: U256) -> Option<Self> {
         let (a, b) = self.overflowing_add_unsigned(rhs);
-        if b {None} else {Some(a)}
+        if b {
+            None
+        } else {
+            Some(a)
+        }
     }
 
     /// Checked integer subtraction. Computes `self - rhs`, returning `None` if
@@ -496,7 +501,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(1).checked_sub_unsigned(U256::new(2)), Some(I256::new(-1)));
     /// assert_eq!((I256::MIN + 2).checked_sub_unsigned(U256::new(3)), None);
     /// ```
@@ -505,7 +511,11 @@ impl I256 {
     #[inline]
     pub fn checked_sub_unsigned(self, rhs: U256) -> Option<Self> {
         let (a, b) = self.overflowing_sub_unsigned(rhs);
-        if b {None} else {Some(a)}
+        if b {
+            None
+        } else {
+            Some(a)
+        }
     }
 
     /// Checked integer multiplication. Computes `self * rhs`, returning `None`
@@ -796,7 +806,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(1).saturating_add_unsigned(U256::new(2)), 3);
     /// assert_eq!(I256::MAX.saturating_add_unsigned(U256::new(100)), I256::MAX);
     /// ```
@@ -805,7 +816,6 @@ impl I256 {
     #[inline]
     pub fn saturating_add_unsigned(self, rhs: U256) -> Self {
         // Overflow can only happen at the upper bound
-        // We cannot use `unwrap_or` here because it is not `const`
         match self.checked_add_unsigned(rhs) {
             Some(x) => x,
             None => Self::MAX,
@@ -849,7 +859,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(100).saturating_sub_unsigned(U256::new(127)), -27);
     /// assert_eq!(I256::MIN.saturating_sub_unsigned(U256::new(100)), I256::MIN);
     /// ```
@@ -858,7 +869,6 @@ impl I256 {
     #[inline]
     pub fn saturating_sub_unsigned(self, rhs: U256) -> Self {
         // Overflow can only happen at the lower bound
-        // We cannot use `unwrap_or` here because it is not `const`
         match self.checked_sub_unsigned(rhs) {
             Some(x) => x,
             None => Self::MIN,
@@ -1019,7 +1029,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(100).wrapping_add_unsigned(U256::new(27)), 127);
     /// assert_eq!(I256::MAX.wrapping_add_unsigned(U256::new(2)), I256::MIN + 1);
     /// ```
@@ -1059,7 +1070,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(0).wrapping_sub_unsigned(U256::new(127)), -127);
     /// assert_eq!(I256::new(-2).wrapping_sub_unsigned(U256::MAX), -1);
     /// ```
@@ -1296,7 +1308,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(100).wrapping_abs(), 100);
     /// assert_eq!(I256::new(-100).wrapping_abs(), 100);
     /// assert_eq!(I256::MIN.wrapping_abs(), I256::MIN);
@@ -1416,7 +1429,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(1).overflowing_add_unsigned(U256::new(2)), (I256::new(3), false));
     /// assert_eq!((I256::MIN).overflowing_add_unsigned(U256::MAX), (I256::MAX, false));
     /// assert_eq!((I256::MAX - 2).overflowing_add_unsigned(U256::new(3)), (I256::MIN, true));
@@ -1465,7 +1479,8 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::I256;
+    /// use ethnum::U256;
     /// assert_eq!(I256::new(1).overflowing_sub_unsigned(U256::new(2)), (I256::new(-1), false));
     /// assert_eq!((I256::MAX).overflowing_sub_unsigned(U256::MAX), (I256::MIN, false));
     /// assert_eq!((I256::MIN + 2).overflowing_sub_unsigned(U256::new(3)), (I256::MAX, true));

--- a/src/int/api.rs
+++ b/src/int/api.rs
@@ -1308,8 +1308,7 @@ impl I256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::I256;
-    /// use ethnum::U256;
+    /// # use ethnum::{I256, U256};
     /// assert_eq!(I256::new(100).wrapping_abs(), 100);
     /// assert_eq!(I256::new(-100).wrapping_abs(), 100);
     /// assert_eq!(I256::MIN.wrapping_abs(), I256::MIN);

--- a/src/uint/api.rs
+++ b/src/uint/api.rs
@@ -425,7 +425,6 @@ impl U256 {
         }
     }
 
-
     /// Checked addition with a signed integer. Computes `self + rhs`,
     /// returning `None` if overflow occurred.
     ///
@@ -434,7 +433,8 @@ impl U256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::U256;
+    /// use ethnum::I256;
     /// assert_eq!(U256::new(1).checked_add_signed(I256::new(2)), Some(U256::new(3)));
     /// assert_eq!(U256::new(1).checked_add_signed(I256::new(-2)), None);
     /// assert_eq!((U256::MAX - 2).checked_add_signed(I256::new(3)), None);
@@ -442,9 +442,13 @@ impl U256 {
     #[must_use = "this returns the result of the operation, \
                     without modifying the original"]
     #[inline]
-    pub fn checked_add_signed(self, rhs: I256 ) -> Option<Self> {
+    pub fn checked_add_signed(self, rhs: I256) -> Option<Self> {
         let (a, b) = self.overflowing_add_signed(rhs);
-        if b {None} else {Some(a)}
+        if b {
+            None
+        } else {
+            Some(a)
+        }
     }
 
     /// Checked integer subtraction. Computes `self - rhs`, returning `None` if
@@ -723,7 +727,8 @@ impl U256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::U256;
+    /// use ethnum::I256;
     /// assert_eq!(U256::new(1).saturating_add_signed(I256::new(2)), U256::new(3));
     /// assert_eq!(U256::new(1).saturating_add_signed(I256::new(-2)), U256::new(0));
     /// assert_eq!((U256::MAX - 2).saturating_add_signed(I256::new(4)), U256::MAX);
@@ -858,7 +863,8 @@ impl U256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::U256;
+    /// use ethnum::I256;
     /// assert_eq!(U256::new(1).wrapping_add_signed(I256::new(2)), U256::new(3));
     /// assert_eq!(U256::new(1).wrapping_add_signed(I256::new(-2)), U256::MAX);
     /// assert_eq!((U256::MAX - 2).wrapping_add_signed(I256::new(4)), U256::new(1));
@@ -1167,7 +1173,8 @@ impl U256 {
     /// Basic usage:
     ///
     /// ```
-    /// # use ethnum::{I256, U256};
+    /// # use ethnum::U256;
+    /// use ethnum::I256;
     /// assert_eq!(U256::new(1).overflowing_add_signed(I256::new(2)), (U256::new(3), false));
     /// assert_eq!(U256::new(1).overflowing_add_signed(I256::new(-2)), (U256::MAX, true));
     /// assert_eq!((U256::MAX - 2).overflowing_add_signed(I256::new(4)), (U256::new(1), true));


### PR DESCRIPTION
This branch implements methods analogous to those of the stable feature [`mixed_integer_ops`](https://github.com/rust-lang/rust/issues/87840).

Closes #24.