### PR TITLE
Inline always

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -170,89 +170,104 @@ impl I256 {
     }
 
     /// Cast to a primitive `i8`.
+    #[inline]
     pub const fn as_i8(self) -> i8 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i16`.
+    #[inline]
     pub const fn as_i16(self) -> i16 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i32`.
+    #[inline]
     pub const fn as_i32(self) -> i32 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i64`.
+    #[inline]
     pub const fn as_i64(self) -> i64 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i128`.
+    #[inline]
     pub const fn as_i128(self) -> i128 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u8`.
+    #[inline]
     pub const fn as_u8(self) -> u8 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u16`.
+    #[inline]
     pub const fn as_u16(self) -> u16 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u32`.
+    #[inline]
     pub const fn as_u32(self) -> u32 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u64`.
+    #[inline]
     pub const fn as_u64(self) -> u64 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u128`.
+    #[inline]
     pub const fn as_u128(self) -> u128 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a `U256`.
+    #[inline]
     pub const fn as_u256(self) -> U256 {
         let Self([a, b]) = self;
         U256([a as _, b as _])
     }
 
     /// Cast to a primitive `isize`.
+    #[inline]
     pub const fn as_isize(self) -> isize {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `usize`.
+    #[inline]
     pub const fn as_usize(self) -> usize {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `f32`.
+    #[inline]
     pub fn as_f32(self) -> f32 {
         self.as_f64() as _
     }
 
     /// Cast to a primitive `f64`.
+    #[inline]
     pub fn as_f64(self) -> f64 {
         let sign = self.signum128() as f64;
         self.unsigned_abs().as_f64() * sign

--- a/src/int/api.rs
+++ b/src/int/api.rs
@@ -126,7 +126,7 @@ impl I256 {
     ///
     /// assert_eq!(n.leading_zeros(), 0);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn leading_zeros(self) -> u32 {
         intrinsics::signed::ictlz(&self)
     }
@@ -144,7 +144,7 @@ impl I256 {
     ///
     /// assert_eq!(n.trailing_zeros(), 2);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn trailing_zeros(self) -> u32 {
         intrinsics::signed::icttz(&self)
     }
@@ -206,7 +206,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn rotate_left(self, n: u32) -> Self {
         let mut r = MaybeUninit::uninit();
         intrinsics::signed::irol3(&mut r, &self, n);
@@ -235,7 +235,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn rotate_right(self, n: u32) -> Self {
         let mut r = MaybeUninit::uninit();
         intrinsics::signed::iror3(&mut r, &self, n);
@@ -317,7 +317,7 @@ impl I256 {
     ///     assert_eq!(I256::from_be(n), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn from_be(x: Self) -> Self {
         #[cfg(target_endian = "big")]
         {
@@ -347,7 +347,7 @@ impl I256 {
     ///     assert_eq!(I256::from_le(n), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn from_le(x: Self) -> Self {
         #[cfg(target_endian = "little")]
         {
@@ -377,7 +377,7 @@ impl I256 {
     ///     assert_eq!(n.to_be(), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn to_be(self) -> Self {
         // or not to be?
         #[cfg(target_endian = "big")]
@@ -408,7 +408,7 @@ impl I256 {
     ///     assert_eq!(n.to_le(), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn to_le(self) -> Self {
         #[cfg(target_endian = "little")]
         {
@@ -792,7 +792,7 @@ impl I256 {
     /// assert_eq!(I256::MAX.saturating_neg(), I256::MIN + 1);
     /// ```
 
-    #[inline]
+    #[inline(always)]
     pub fn saturating_neg(self) -> Self {
         I256::ZERO.saturating_sub(self)
     }
@@ -916,7 +916,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_add(self, rhs: Self) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::iadd3(&mut result, &self, &rhs);
@@ -937,7 +937,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_sub(self, rhs: Self) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::isub3(&mut result, &self, &rhs);
@@ -958,7 +958,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_mul(self, rhs: Self) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::imul3(&mut result, &self, &rhs);
@@ -1094,7 +1094,7 @@ impl I256 {
     /// assert_eq!(I256::new(100).wrapping_neg(), -100);
     /// assert_eq!(I256::MIN.wrapping_neg(), I256::MIN);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_neg(self) -> Self {
         Self::ZERO.wrapping_sub(self)
     }
@@ -1121,7 +1121,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_shl(self, rhs: u32) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::ishl3(&mut result, &self, rhs & 0xff);
@@ -1150,7 +1150,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_shr(self, rhs: u32) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::isar3(&mut result, &self, rhs & 0xff);
@@ -1212,7 +1212,7 @@ impl I256 {
     ///     ),
     /// );
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn unsigned_abs(self) -> U256 {
         self.wrapping_abs().as_u256()
     }
@@ -1272,7 +1272,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_add(self, rhs: Self) -> (Self, bool) {
         let mut result = MaybeUninit::uninit();
         let overflow = intrinsics::signed::iaddc(&mut result, &self, &rhs);
@@ -1296,7 +1296,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
         let mut result = MaybeUninit::uninit();
         let overflow = intrinsics::signed::isubc(&mut result, &self, &rhs);
@@ -1362,7 +1362,7 @@ impl I256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
         let mut result = MaybeUninit::uninit();
         let overflow = intrinsics::signed::imulc(&mut result, &self, &rhs);
@@ -1807,7 +1807,7 @@ impl I256 {
     /// assert_eq!(I256::new(0).signum(), 0);
     /// assert_eq!(I256::new(-10).signum(), -1);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn signum(self) -> Self {
         I256::new(self.signum128())
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -167,84 +167,98 @@ impl U256 {
     }
 
     /// Cast to a primitive `i8`.
+    #[inline]
     pub const fn as_i8(self) -> i8 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i16`.
+    #[inline]
     pub const fn as_i16(self) -> i16 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i32`.
+    #[inline]
     pub const fn as_i32(self) -> i32 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i64`.
+    #[inline]
     pub const fn as_i64(self) -> i64 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `i128`.
+    #[inline]
     pub const fn as_i128(self) -> i128 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a `I256`.
+    #[inline]
     pub const fn as_i256(self) -> I256 {
         let Self([a, b]) = self;
         I256([a as _, b as _])
     }
 
     /// Cast to a primitive `u8`.
+    #[inline]
     pub const fn as_u8(self) -> u8 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u16`.
+    #[inline]
     pub const fn as_u16(self) -> u16 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u32`.
+    #[inline]
     pub const fn as_u32(self) -> u32 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u64`.
+    #[inline]
     pub const fn as_u64(self) -> u64 {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `u128`.
+    #[inline]
     pub const fn as_u128(self) -> u128 {
         let (_, lo) = self.into_words();
         lo
     }
 
     /// Cast to a primitive `isize`.
+    #[inline]
     pub const fn as_isize(self) -> isize {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `usize`.
+    #[inline]
     pub const fn as_usize(self) -> usize {
         let (_, lo) = self.into_words();
         lo as _
     }
 
     /// Cast to a primitive `f32`.
+    #[inline]
     pub fn as_f32(self) -> f32 {
         match self.into_words() {
             (0, lo) => lo as _,
@@ -253,6 +267,7 @@ impl U256 {
     }
 
     /// Cast to a primitive `f64`.
+    #[inline]
     pub fn as_f64(self) -> f64 {
         // NOTE: Binary representation of 2**128. This is used because `powi` is
         // neither `const` nor `no_std`.

--- a/src/uint/api.rs
+++ b/src/uint/api.rs
@@ -119,7 +119,7 @@ impl U256 {
     /// let n = U256::MAX >> 2u32;
     /// assert_eq!(n.leading_zeros(), 2);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn leading_zeros(self) -> u32 {
         intrinsics::signed::uctlz(&self)
     }
@@ -136,7 +136,7 @@ impl U256 {
     /// let n = U256::new(0b0101000);
     /// assert_eq!(n.trailing_zeros(), 3);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn trailing_zeros(self) -> u32 {
         intrinsics::signed::ucttz(&self)
     }
@@ -196,7 +196,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn rotate_left(self, n: u32) -> Self {
         let mut r = MaybeUninit::uninit();
         intrinsics::signed::urol3(&mut r, &self, n);
@@ -224,7 +224,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn rotate_right(self, n: u32) -> Self {
         let mut r = MaybeUninit::uninit();
         intrinsics::signed::uror3(&mut r, &self, n);
@@ -300,7 +300,7 @@ impl U256 {
     ///     assert_eq!(U256::from_be(n), n.swap_bytes());
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     #[allow(clippy::wrong_self_convention)]
     pub const fn from_be(x: Self) -> Self {
         #[cfg(target_endian = "big")]
@@ -330,7 +330,7 @@ impl U256 {
     ///     assert_eq!(U256::from_le(n), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     #[allow(clippy::wrong_self_convention)]
     pub const fn from_le(x: Self) -> Self {
         #[cfg(target_endian = "little")]
@@ -360,7 +360,7 @@ impl U256 {
     ///     assert_eq!(n.to_be(), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn to_be(self) -> Self {
         #[cfg(target_endian = "big")]
         {
@@ -389,7 +389,7 @@ impl U256 {
     ///     assert_eq!(n.to_le(), n.swap_bytes())
     /// }
     /// ```
-    #[inline]
+    #[inline(always)]
     pub const fn to_le(self) -> Self {
         #[cfg(target_endian = "little")]
         {
@@ -752,7 +752,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn saturating_div(self, rhs: Self) -> Self {
         // on unsigned types, there is no overflow in integer division
         self.wrapping_div(rhs)
@@ -794,7 +794,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_add(self, rhs: Self) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::uadd3(&mut result, &self, &rhs);
@@ -815,7 +815,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_sub(self, rhs: Self) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::usub3(&mut result, &self, &rhs);
@@ -839,7 +839,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_mul(self, rhs: Self) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::umul3(&mut result, &self, &rhs);
@@ -861,7 +861,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_div(self, rhs: Self) -> Self {
         self / rhs
     }
@@ -883,7 +883,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
         self / rhs
     }
@@ -903,7 +903,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_rem(self, rhs: Self) -> Self {
         self % rhs
     }
@@ -925,7 +925,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
         self % rhs
     }
@@ -984,7 +984,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_shl(self, rhs: u32) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::ushl3(&mut result, &self, rhs & 0xff);
@@ -1013,7 +1013,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn wrapping_shr(self, rhs: u32) -> Self {
         let mut result = MaybeUninit::uninit();
         intrinsics::signed::ushr3(&mut result, &self, rhs & 0xff);
@@ -1080,7 +1080,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_add(self, rhs: Self) -> (Self, bool) {
         let mut result = MaybeUninit::uninit();
         let overflow = intrinsics::signed::uaddc(&mut result, &self, &rhs);
@@ -1104,7 +1104,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
         let mut result = MaybeUninit::uninit();
         let overflow = intrinsics::signed::usubc(&mut result, &self, &rhs);
@@ -1156,7 +1156,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
         let mut result = MaybeUninit::uninit();
         let overflow = intrinsics::signed::umulc(&mut result, &self, &rhs);
@@ -1183,7 +1183,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
         (self / rhs, false)
     }
@@ -1210,7 +1210,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
         (self / rhs, false)
     }
@@ -1236,7 +1236,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
         (self % rhs, false)
     }
@@ -1265,7 +1265,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
         (self % rhs, false)
     }
@@ -1310,7 +1310,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_shl(self, rhs: u32) -> (Self, bool) {
         (self.wrapping_shl(rhs), rhs > 255)
     }
@@ -1334,7 +1334,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn overflowing_shr(self, rhs: u32) -> (Self, bool) {
         (self.wrapping_shr(rhs), rhs > 255)
     }
@@ -1450,7 +1450,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn div_euclid(self, rhs: Self) -> Self {
         self / rhs
     }
@@ -1474,7 +1474,7 @@ impl U256 {
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[inline(always)]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         self % rhs
     }


### PR DESCRIPTION
Using the corresponding functions in the core library as a guide, I conservatively turned several `#[inline]`s into #[inline(always)]s. I also added `#[inline]` to some functions that didn't have it but should.