### PR TITLE
Fix LTO Detection in LLVM Intrinsic Build

### DIFF
--- a/intrinsics/build/main.rs
+++ b/intrinsics/build/main.rs
@@ -50,8 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut build = Build::new();
     build.compiler(&clang).file(intrinsics_ir_path).opt_level(3);
 
-    let linker_plugin_lto =
-        matches!(env::var("RUSTFLAGS"), Ok(flags) if flags.contains("-Clinker-plugin-lto"));
+    let linker_plugin_lto = matches!(env::var("CARGO_ENCODED_RUSTFLAGS"), Ok(flags) if flags.contains("-Clinker-plugin-lto"));
     if linker_plugin_lto {
         build.flag("-flto=thin");
     }


### PR DESCRIPTION
Fixes #33 

This PR fixes LTO detection in the LLVM intrinsic build script. It turns out that around Rust 1.55, `cargo` stopped propagating `RUSTFLAGS` environment variable to the build script invocation (and even actively removing it). It is replaced with `CARGO_ENCODED_RUSTFLAGS` which is meant to more accurately set the actual `rustc` flags that are being used.

Turning this on yields an immediate improvement in benchmarks:

```
U256::add               time:   [15.726 ns 15.764 ns 15.808 ns]
                        change: [-34.507% -34.304% -34.099%] (p = 0.00 < 0.05)
                        Performance has improved.
```