### PR TITLE
Native Rotation Intrinsic Optimization

### DIFF
--- a/src/intrinsics/native/rot.rs
+++ b/src/intrinsics/native/rot.rs
@@ -6,10 +6,48 @@ use core::mem::MaybeUninit;
 
 #[inline]
 pub fn rol3(r: &mut MaybeUninit<U256>, a: &U256, b: u32) {
-    r.write((a << (b & 0xff)) | (a >> ((256 - b) & 0xff)));
+    let lmask = u64::MAX.wrapping_shl(b);
+    let rmask = !lmask;
+    let mut arr = unsafe { core::mem::transmute::<U256, [u64; 4]>(*a) };
+    let mut arr_2 = [0u64; 4];
+    for i in 0..4 {
+        arr[i] = arr[i].rotate_left(b);
+        arr_2[i] = arr[i] & rmask;
+        arr[i] &= lmask;
+    }
+    for i in 0..4 {
+        #[cfg(target_endian = "little")]
+        {
+            arr[i] |= arr_2[(i + 3) & 3];
+        }
+        #[cfg(target_endian = "big")]
+        {
+            arr[i] |= arr_2[(i + 1) & 3];
+        }
+    }
+    if b & 128 != 0 {
+        if b & 64 != 0 {
+            r.write(unsafe { core::mem::transmute::<[u64; 4], U256>(
+                [arr[1], arr[2], arr[3], arr[0]]
+            ) });
+        } else {
+            r.write(unsafe { core::mem::transmute::<[u64; 4], U256>(
+                [arr[2], arr[3], arr[0], arr[1]]
+            ) });
+        }
+    } else {
+        if b & 64 != 0 {
+            r.write(unsafe { core::mem::transmute::<[u64; 4], U256>(
+                [arr[3], arr[0], arr[1], arr[2]]
+            ) });
+        } else {
+            r.write(unsafe { core::mem::transmute::<[u64; 4], U256>(arr) });
+        }
+    }
 }
 
+// Perhaps this function should get its own code.
 #[inline]
 pub fn ror3(r: &mut MaybeUninit<U256>, a: &U256, b: u32) {
-    r.write((a >> (b & 0xff)) | (a << ((256 - b) & 0xff)));
+    rol3(r, a, 0u32.wrapping_sub(b) & 255)
 }


### PR DESCRIPTION
I removed some redundancies in `rol3`. On generic x86_64, the rotate left short benchmark got a 44% time reduction to 4.25ns and rotate left long got 34% improvement to 4.6ns. On the same computer with `target-cpu=skylake`, both benchmark times got approximately halved to 3.45ns. Hopefully native rol3 is called more than 2 * 10^13 times in the future so my time spent was worth while.

I marked it draft because two things need to happen:
* `ror3` needs to be optimized as well. I set to just negate `b` and call `rol3`. This is still an improvement over the status quo, but on generic x86_64, rotate right gets considerably worse benchmark scores than rotate rotate left. My only hypothesis is that the negation tips it over the edge of an inlining threshold. I'll give it its own mirror of `rol3`.
* The new function needs to be benchmarked on other architectures. This is particularily important because I explicitly wrote the new version with 64-bit operations in mind, so it might be a pessimization on 32 bit architectures. We may need to either use 32-bit integers instead, or maybe go the opposite direction to 128-bit. There is also some endianness-specific code. It is pretty simple, but it should be checked for correctness to be safe. I only have access to x86_64 and 64-bit ARM so I need someone else to test this for me.