### PR TITLE
Made Equality Tests Smarter

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -13,7 +13,7 @@ use crate::uint::U256;
 use core::num::ParseIntError;
 
 /// A 256-bit signed integer type.
-#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, Hash)]
 #[repr(transparent)]
 pub struct I256(pub [i128; 2]);
 

--- a/src/macros/cmp.rs
+++ b/src/macros/cmp.rs
@@ -11,6 +11,17 @@ macro_rules! impl_cmp {
             }
         }
 
+        impl PartialEq for $int {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                let (ahi, alo) = self.into_words();
+                let (bhi, blo) = other.into_words();
+                (ahi == bhi) & (alo == blo)
+                // bitwise and rather than logical and
+                // to make O0 code more effecient.
+            }
+        }
+
         impl PartialEq<$prim> for $int {
             #[inline]
             fn eq(&self, other: &$prim) -> bool {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -13,7 +13,7 @@ use crate::I256;
 use core::num::ParseIntError;
 
 /// A 256-bit unsigned integer type.
-#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, Hash)]
 #[repr(transparent)]
 pub struct U256(pub [u128; 2]);
 


### PR DESCRIPTION
Currently, `==` compares the underlying arrays. This compiles to `memcmp` in llvm. `memcmp` is then optimized to `bcmp`. The problem with this is that llvm-opt doesn't do much with bcmp during the instcombine pass. It will also sometimes write to memory just to read it back again.

What I did to work around this in div-rem was use `unreachable_unchecked()` calls to tell the compiler that the `bcmp` is equivalent to two `icmp`s. I have considered overloading the `==` operator with a `bcmp` plus hints, but now I believe it is best to not use `bcmp` at all. Ethnum's integers have public fields, so the current equality operation can always be called with `a.0 == b.0`.

I compared and annotated a few alternatives on [Compiler Explorer](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywYhJAZlKOAMngMmABy7gBGmMQgAOy%2BAA6oCoR2DC5uHl4JSSkCgcFhLJHRcZaY1rYCQgRMxATp7p4%2BZRWp1bUE%2BaERUbG%2B5h0Nmc0DdV2FxX0AlJaoJsTI7BxmmADU5uggKCzxWwDyxFjEQcAApN4AQqcaAILXN1QMqwQm8fQA%2Bsg7EEwgq6cAJgAbKcAKwXExcAEADnOF1WALBABFSKtwn9ASDwZCYXCEcipqsALTnbCrA5HE7/GJXW6remrH5gi5cZGopjMjQEgB0X3iEExEHCzNZoJRaM5BKm91OMSRMtuAHpFas5Ax6AoFM8EGtUPECET6AA3cqrPBava%2BbXm1YAdzotFWVCYdGeqCdJlotAAnqs9bYWHgAF6Ybn3ZWrAAqCCYBFWMa1TFWwWAsbwJtWmCoVEwNj9T1EXqpVBMDBsqQU93iJnCToLO3emAAjj8McDmTjYZd8WLUej/u3sVCu/DEWLCSTvGTwqhXNTaTcGc9Xh8%2BT8%2B4TzvLvEjyYcoicttgmyYxDK5QqbhHozaE9rdfq8Cwg2mBIm43suNrY6s%2BY2m/mPrxkwlZKiqP6WlWNZ1subyYP%2BrYDliELDniY7iv2mIdqh3boROpJorOjqyguS5MuCorihy4JcuO/w7lujLChRbISjRBLnvKtzhiqN5avEUT8MQLBapEBAEFE35PC8cH/nahAIOSGh9iYcbmjxfoEDqxD2ko97rKwoYaQAkqsxC5qgbAMOgfomsQtCoEw%2BBGPpW6MXqUSxiQ8ladaWpCRpAKgkCaKEGagiYMAUQKGGtzVrWjyhQQunwc2iFYUOuK4axmGDihWWjgSxIETOc4kfcZHUSyyL0duu7MdVdGYoyVW0bubk7mxFxtdK3EXtxYGrAA6gp%2BlYM6npxko4knBaX6GDZryolpNpRcExCxpgWpaZgGkKIZqwgUoRRASB%2BnJe6TAzia3LDaNRJOM8tRRQayDVluCgANbegYn2YKQGlmnG8TEBgJiLFqCi0HgwAIAQQFiRJxCHZqmAnb64S%2BmYVI3AAagAGgCsVXiqNxaqgVB2scthGMtCA2jaO3rDULxaie7pCZmWkMO4RLEDFGlqtDf2HV6qwg5gRp2GYqxsFpGAKHTNpoDsdBbW6sto3yGkLWivqYKoEkMMkAhony4WrF6RosLd0a6jt/OrCsZp8sT8UwbUxAIb8SHYQVPYYW2yGdmhRWTtORHzhVDJJh19WcZe7uJeZ6ClughgEO84SECl3tB37I4B32%2BeZYXeHFVOhFlTS0f0tnyXmqlLZMBuvvAkludpeE7K9Xc/V3INduHcQG2%2BnLCAYGaWoMKgcYEBtxvxLUjBz%2B6TP%2Bk%2BwZRKi9paXtllrAbiyPm%2BbvQcnmCp9ZGfvJ7ee%2B6Xoe9miJf5WXYclZH5V0jHI/e63WF253y7j3BOA0SZ3V8goA%2Bv5LLxDVsjaaNNgCK30vTQQoknIIyYMgT6NBzIA0GrrQgYAOBahjIcDWEt8A2DPglJ46CJLoFvn/NKPsMpvyfoHB%2BnDsp0XDlXYiNcf70jwJTWODFOq1m/ouJcDIxEtRFKxVqRUwBgEYkKJRz8Go9SjiIuRS5Sz7RzPOZmmwQCMK2KWcyOCYzhA%2BKWZAOpcGXwgJufuBj6Syi4rIgx88TC7X0d4zMtA9IyM8WaSm5FGpUUlE1SRu5NEsW0XEpE7jSIRIZEYpgJiSJmK2JYkA1jMC2Kug4sszi/roDcdSHxETvG1zkc6UJgTfG1LAQPCBfF1gT1tNtHU8YggEC1EEQ65YBCohYEwT6VJGGXxYcQDSG8pmOlGdAtg6wBKLBoMgX8eAFjuAGGWLat0AASqBbSS23hpMKjN3RBDQMbc0Rs4yczWp5R0Kw6EwRTmnG%2BczmHAObq/EOfDuEcNBYVfhn9q4ZPpAChZ/80SbnbO3BFQKhSgL6j4jSNwZ4Oz9CfJ4to5i0BspEVY%2BBzI2CAtjFyVsWCkK1EFIERJ643NdlGemWo0CenJWsdAAg1i70UpgbmvN%2BZMstrQa2RIhnHCecgUCECcyxnmKGVYpkYwmgYKQuMDlUBVI1s6ZGQz7kWDRKpQ6yY0wmiWeqX0T44JWRZqkdYmA0b%2BSCGsTmM9bTcg4DMWgnBQS8E8BwLQpBUCcAAEpmCmnMBYaxATeB4KQAgmhA0zE%2BiAUEylg0cEkGGzNUbOC8AUCAZSGaI2BtIHAWASAVbwPoGQCgEAm0IJAMQLgcRlI0FoEjCtQoS3Z2YMQb0nA02jtqN6PY4RtC5mrWmlWLq9gOpLVgcIJhgBODEKEydvAsBTKMOIGtpAqWLvTFtEtBtcyqSWGmoZ5QS3Q3CBtcdLgsAlvnk%2BA9MwqAGBQbjPAmBbR7AEuGtN/BBAiDEOwKQMhBCKBUOoM9uguD6EMMYeN%2Bg8DhArZAGYG83ycAepkzx/pDRXNoFuAEvBUB2WOFgAjbiWiXvsBARwQxPAYYCN6iYvQMOJGSJUNIrhGh6GE7kBg4wejRAw1YdjDB2h1G43oRT4zlM1DGPxuT6ntP1HE5kBTBnZNFEEzMaB8xFgSCDSG4tZ7o0cDMvG3ZXBuRxG5BoRkuBCDeRTVwKYvBq1aCmNm3N%2BbOBFtIOGyNTny2VvTZmsL%2BhOB0dICwCQGhlKxfo2WpLNaUt2RNk0IAA%3D). Note that I have not considered adding an llvm intrinsic.