### PR TITLE
feat: Add borsh binary serializer to i256 and u256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 [features]
 llvm-intrinsics = ["ethnum-intrinsics"]
 macros = [] # deprecated
+borsh = ["dep:borsh"]
 
 [dependencies]
 ethnum-intrinsics = { version = "=1.2.0", path = "intrinsics", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ macros = [] # deprecated
 [dependencies]
 ethnum-intrinsics = { version = "=1.2.0", path = "intrinsics", optional = true }
 serde = { version = "1", default-features = false, optional = true }
+borsh = { version = "1.2.1", default-features = false, optional = true }

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -28,7 +28,7 @@ impl borsh::BorshDeserialize for U256 {
 
 #[cfg(test)]
 mod borsh_tests {
-    use crate::I256;
+    use crate::{I256, U256};
 
     #[test]
     fn test_borsh_i256() {
@@ -36,5 +36,23 @@ mod borsh_tests {
         let buffer = borsh::to_vec(&i).expect("failed to serialize value");
         let deser_i: I256 = borsh::from_slice(&buffer).expect("failed to deserialize value");
         assert_eq!(deser_i, i);
+
+        let i = I256::MAX;
+        let buffer = borsh::to_vec(&i).expect("failed to serialize value");
+        let deser_i: I256 = borsh::from_slice(&buffer).expect("failed to deserialize value");
+        assert_eq!(deser_i, i);
+    }
+
+    #[test]
+    fn test_borsh_u256() {
+        let u = U256::MIN;
+        let buffer = borsh::to_vec(&u).expect("failed to serialize value");
+        let deser_u: U256 = borsh::from_slice(&buffer).expect("failed to deserialize value");
+        assert_eq!(deser_u, u);
+
+        let u = U256::MAX;
+        let buffer = borsh::to_vec(&u).expect("failed to serialize value");
+        let deser_u: U256 = borsh::from_slice(&buffer).expect("failed to deserialize value");
+        assert_eq!(deser_u, u);
     }
 }

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -1,0 +1,40 @@
+use crate::{I256, U256};
+
+impl borsh::BorshSerialize for I256 {
+    fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        self.0.serialize(writer)
+    }
+}
+
+impl borsh::BorshSerialize for U256 {
+    fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        self.0.serialize(writer)
+    }
+}
+
+impl borsh::BorshDeserialize for I256 {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        let value: [i128; 2] = borsh::BorshDeserialize::deserialize_reader(reader)?;
+        Ok(Self(value))
+    }
+}
+
+impl borsh::BorshDeserialize for U256 {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        let value: [u128; 2] = borsh::BorshDeserialize::deserialize_reader(reader)?;
+        Ok(Self(value))
+    }
+}
+
+#[cfg(test)]
+mod borsh_tests {
+    use crate::I256;
+
+    #[test]
+    fn test_borsh_i256() {
+        let i = I256::MIN;
+        let buffer = borsh::to_vec(&i).expect("failed to serialize value");
+        let deser_i: I256 = borsh::from_slice(&buffer).expect("failed to deserialize value");
+        assert_eq!(deser_i, i);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ mod macros {
     pub mod parse;
 }
 
+#[cfg(feature = "borsh")]
+pub mod borsh;
 mod error;
 mod fmt;
 mod int;


### PR DESCRIPTION
Add [borsh](https://borsh.io/) binary serializer to i256 and u256.