### PR TITLE
Implement `Hash` Manually

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -13,7 +13,7 @@ use crate::uint::U256;
 use core::{mem::MaybeUninit, num::ParseIntError};
 
 /// A 256-bit signed integer type.
-#[derive(Clone, Copy, Default, Eq, Hash)]
+#[derive(Clone, Copy, Default, Eq)]
 #[repr(transparent)]
 pub struct I256(pub [i128; 2]);
 

--- a/src/macros/cmp.rs
+++ b/src/macros/cmp.rs
@@ -4,10 +4,13 @@ macro_rules! impl_cmp {
     (
         impl Cmp for $int:ident ($prim:ident);
     ) => {
-        impl PartialOrd for $int {
+        impl ::core::hash::Hash for $int {
             #[inline]
-            fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
-                Some(self.cmp(other))
+            fn hash<H>(&self, hasher: &mut H)
+            where
+                H: ::core::hash::Hasher,
+            {
+                ::core::hash::Hash::hash(&self.0, hasher);
             }
         }
 
@@ -33,6 +36,13 @@ macro_rules! impl_cmp {
             #[inline]
             fn eq(&self, other: &$int) -> bool {
                 $int::new(*self) == *other
+            }
+        }
+
+        impl PartialOrd for $int {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+                Some(self.cmp(other))
             }
         }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -13,7 +13,7 @@ use crate::I256;
 use core::{mem::MaybeUninit, num::ParseIntError};
 
 /// A 256-bit unsigned integer type.
-#[derive(Clone, Copy, Default, Eq, Hash)]
+#[derive(Clone, Copy, Default, Eq)]
 #[repr(transparent)]
 pub struct U256(pub [u128; 2]);
 


### PR DESCRIPTION
Addresses a clippy lint that you should not derive `Hash` and implement `PartialEq`.