### PR TITLE
Temporarily Revert Manual `PartialEq` Implementation

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -13,7 +13,7 @@ use crate::uint::U256;
 use core::{mem::MaybeUninit, num::ParseIntError};
 
 /// A 256-bit signed integer type.
-#[derive(Clone, Copy, Default, Eq)]
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct I256(pub [i128; 2]);
 

--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -1,5 +1,19 @@
 //! Module with comparison implementations for `I256`.
 //!
+//! `PartialEq` is derived and not implemented, which is important for ensuring
+//! that `match` can be used with `I256`.
+//!
+//! ```
+//! # use ethnum::I256;
+//! # let value = I256::new(42);
+//!
+//! match (value) {
+//!     I256::ZERO => println!("I am zero"),
+//!     I256::ONE => println!("I am one"),
+//!     _ => println!("I am something else"),
+//! }
+//! ```
+//!
 //! `PartialEq` and `PartialOrd` implementations for `i128` are also provided
 //! to allow notation such as:
 //!

--- a/src/macros/cmp.rs
+++ b/src/macros/cmp.rs
@@ -4,27 +4,6 @@ macro_rules! impl_cmp {
     (
         impl Cmp for $int:ident ($prim:ident);
     ) => {
-        impl ::core::hash::Hash for $int {
-            #[inline]
-            fn hash<H>(&self, hasher: &mut H)
-            where
-                H: ::core::hash::Hasher,
-            {
-                ::core::hash::Hash::hash(&self.0, hasher);
-            }
-        }
-
-        impl PartialEq for $int {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                let (ahi, alo) = self.into_words();
-                let (bhi, blo) = other.into_words();
-                (ahi == bhi) & (alo == blo)
-                // bitwise and rather than logical and
-                // to make O0 code more effecient.
-            }
-        }
-
         impl PartialEq<$prim> for $int {
             #[inline]
             fn eq(&self, other: &$prim) -> bool {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -13,7 +13,7 @@ use crate::I256;
 use core::{mem::MaybeUninit, num::ParseIntError};
 
 /// A 256-bit unsigned integer type.
-#[derive(Clone, Copy, Default, Eq)]
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct U256(pub [u128; 2]);
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -1,5 +1,19 @@
 //! Module with comparison implementations for `U256`.
 //!
+//! `PartialEq` is derived and not implemented, which is important for ensuring
+//! that `match` can be used with `U256`.
+//!
+//! ```
+//! # use ethnum::U256;
+//! # let value = U256::new(42);
+//!
+//! match (value) {
+//!     U256::ZERO => println!("I am zero"),
+//!     U256::ONE => println!("I am one"),
+//!     _ => println!("I am something else"),
+//! }
+//! ```
+//!
 //! `PartialEq` and `PartialOrd` implementations for `u128` are also provided
 //! to allow notation such as:
 //!


### PR DESCRIPTION
It prevents const-comparisons and `match`-ing with constants. See #50 for more details.

We can go back to the manual `PartialEq` implementation once `StructuralPartialEq` is stabalized.

This reverts commit 87e6888301af85c96a2fad9a28004a744808db7a.